### PR TITLE
fix(android): compilation errors when using expo sdk 52

### DIFF
--- a/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
@@ -56,9 +56,9 @@ class ExpoSpotifySDKModule : Module() {
         val packageInfo =
           context.packageManager.getPackageInfo(context.packageName, PackageManager.GET_META_DATA)
         val applicationInfo = packageInfo.applicationInfo
-        val metaData = applicationInfo.metaData
-        val clientId = metaData.getString("spotifyClientId")
-        val redirectUri = metaData.getString("spotifyRedirectUri")
+        val metaData = applicationInfo?.metaData
+        val clientId = metaData?.getString("spotifyClientId")
+        val redirectUri = metaData?.getString("spotifyRedirectUri")
 
         requestConfig = config
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the authentication process to prevent crashes due to null metadata retrieval.
	- Enhanced safety when accessing Spotify configuration parameters.

These changes ensure a more stable and reliable authentication experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->