### PR TITLE
feat: add showDialog option to authenticateAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Starts a Spotify OAuth flow. If the Spotify app is installed it authenticates na
 | `scopes`          | `SpotifyScope[]` | ✅       | OAuth scopes to request. Must contain at least one entry.                                                                  |
 | `tokenSwapURL`    | `string`         | —        | URL of your token swap server endpoint. Triggers CODE flow (recommended). Required on Android to receive a `refreshToken`. |
 | `tokenRefreshURL` | `string`         | —        | URL of your token refresh server endpoint. Used by iOS SDK natively and by `refreshSessionAsync` on both platforms.        |
+| `showDialog`      | `boolean`        | —        | Force Spotify to show the authorization dialog even when the user already has an active session. Defaults to `false`. Useful during development; avoid in production.        |
 
 **Returns (`SpotifySession`):**
 

--- a/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
@@ -94,6 +94,7 @@ class ExpoSpotifySDKModule : Module() {
           redirectUri = manifest.redirectUri,
           responseType = responseType,
           scopes = config.scopes.toTypedArray(),
+          showDialog = config.showDialog,
         )
 
         val response = coordinator.authenticate(authLauncher, input)

--- a/android/src/main/java/expo/modules/spotifysdk/SpotifyAuthorizationContract.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/SpotifyAuthorizationContract.kt
@@ -33,6 +33,7 @@ class SpotifyAuthorizationContract :
       input.redirectUri,
     )
       .setScopes(input.scopes)
+      .setShowDialog(input.showDialog)
       .build()
     return AuthorizationClient.createLoginActivityIntent(activity, request)
   }

--- a/android/src/main/java/expo/modules/spotifysdk/SpotifyConfig.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/SpotifyConfig.kt
@@ -12,6 +12,7 @@ class SpotifyAuthenticateOptions : Record {
   @Field val scopes: List<String> = emptyList()
   @Field val tokenSwapURL: String? = null
   @Field val tokenRefreshURL: String? = null
+  @Field val showDialog: Boolean = false
 }
 
 /**
@@ -60,6 +61,7 @@ data class SpotifyAuthInput(
   val redirectUri: String,
   val responseType: AuthorizationResponse.Type,
   val scopes: Array<String>,
+  val showDialog: Boolean,
 ) : Serializable {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -67,7 +69,8 @@ data class SpotifyAuthInput(
     return clientId == other.clientId &&
       redirectUri == other.redirectUri &&
       responseType == other.responseType &&
-      scopes.contentEquals(other.scopes)
+      scopes.contentEquals(other.scopes) &&
+      showDialog == other.showDialog
   }
 
   override fun hashCode(): Int {
@@ -75,6 +78,7 @@ data class SpotifyAuthInput(
     result = 31 * result + redirectUri.hashCode()
     result = 31 * result + responseType.hashCode()
     result = 31 * result + scopes.contentHashCode()
+    result = 31 * result + showDialog.hashCode()
     return result
   }
 }

--- a/ios/ExpoSpotifySDKModule.swift
+++ b/ios/ExpoSpotifySDKModule.swift
@@ -28,7 +28,8 @@ public class ExpoSpotifySDKModule: Module {
         let session = try await coordinator.authenticate(
           scopes: scopes,
           tokenSwapURL: config.tokenSwapURL.flatMap(URL.init),
-          tokenRefreshURL: config.tokenRefreshURL.flatMap(URL.init)
+          tokenRefreshURL: config.tokenRefreshURL.flatMap(URL.init),
+          showDialog: config.showDialog
         )
         let map = self.sessionToMap(session)
         self.sendEvent(EVENT_SESSION_CHANGE, ["type": "didInitiate", "session": map])
@@ -99,6 +100,7 @@ struct AuthenticateOptions: Record {
   @Field var scopes: [String] = []
   @Field var tokenSwapURL: String? = nil
   @Field var tokenRefreshURL: String? = nil
+  @Field var showDialog: Bool = false
 }
 
 struct RefreshOptions: Record {

--- a/ios/SpotifyAuthCoordinator.swift
+++ b/ios/SpotifyAuthCoordinator.swift
@@ -78,7 +78,8 @@ actor SpotifyAuthCoordinator {
   func authenticate(
     scopes: SPTScope,
     tokenSwapURL: URL?,
-    tokenRefreshURL: URL?
+    tokenRefreshURL: URL?,
+    showDialog: Bool = false
   ) async throws -> SPTSession {
     guard pending == nil else { throw SpotifyError.authInProgress }
 
@@ -86,6 +87,17 @@ actor SpotifyAuthCoordinator {
     // mutating it here takes effect for the upcoming initiateSession call.
     sptConfiguration.tokenSwapURL = tokenSwapURL
     sptConfiguration.tokenRefreshURL = tokenRefreshURL
+    // alwaysShowAuthorizationDialog is a property on SPTSessionManager, not an
+    // SPTAuthorizationOptions flag (the options enum has no such case).
+    sessionManager.alwaysShowAuthorizationDialog = showDialog
+
+    NSLog(
+      "[ExpoSpotifySDK] initiateSession redirectURL=%@ tokenSwapURL=%@ tokenRefreshURL=%@ showDialog=%d",
+      sptConfiguration.redirectURL.absoluteString,
+      tokenSwapURL?.absoluteString ?? "nil",
+      tokenRefreshURL?.absoluteString ?? "nil",
+      showDialog ? 1 : 0
+    )
 
     return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<SPTSession, Error>) in
       self.pending = cont
@@ -109,15 +121,28 @@ final class SpotifySessionDelegateBridge: NSObject, SPTSessionManagerDelegate {
   weak var coordinator: SpotifyAuthCoordinator?
 
   func sessionManager(manager _: SPTSessionManager, didInitiate session: SPTSession) {
+    NSLog(
+      "[ExpoSpotifySDK] didInitiate accessToken.length=%d refreshToken.length=%d expirationDate=%@ scope=%lu",
+      session.accessToken.count,
+      session.refreshToken.count,
+      session.expirationDate as NSDate,
+      session.scope.rawValue
+    )
     Task { await coordinator?.deliver(.success(session)) }
   }
 
   func sessionManager(manager _: SPTSessionManager, didFailWith error: Error) {
     let mapped: Error = mapSDKError(error)
+    NSLog("[ExpoSpotifySDK] didFailWithError %@", String(describing: error))
     Task { await coordinator?.deliver(.failure(mapped)) }
   }
 
   func sessionManager(manager _: SPTSessionManager, didRenew session: SPTSession) {
+    NSLog(
+      "[ExpoSpotifySDK] didRenew accessToken.length=%d refreshToken.length=%d",
+      session.accessToken.count,
+      session.refreshToken.count
+    )
     Task { await coordinator?.deliver(.success(session)) }
   }
 
@@ -128,6 +153,34 @@ final class SpotifySessionDelegateBridge: NSObject, SPTSessionManagerDelegate {
     if description.contains("cancel") {
       return SpotifyError.userCancelled
     }
-    return SpotifyError.underlying(error)
+    return SpotifyError.underlying(NSError(
+      domain: nsError.domain,
+      code: nsError.code,
+      userInfo: [NSLocalizedDescriptionKey: describeError(nsError)]
+    ))
+  }
+
+  /// Build a diagnostic string from an NSError that includes the domain,
+  /// code, localized description, and the full chain of underlying errors.
+  /// Used because `SPTError` (and many `URLSession` errors it wraps) often
+  /// have an empty `localizedDescription`, surfacing as "undefined reason"
+  /// in JS without this expansion.
+  private func describeError(_ error: NSError) -> String {
+    var parts: [String] = []
+    parts.append("\(error.domain) code \(error.code)")
+    let desc = error.localizedDescription
+    if !desc.isEmpty {
+      parts.append("\"\(desc)\"")
+    }
+    var ui = error.userInfo
+    ui.removeValue(forKey: NSUnderlyingErrorKey)
+    ui.removeValue(forKey: NSLocalizedDescriptionKey)
+    if !ui.isEmpty {
+      parts.append("userInfo=\(ui)")
+    }
+    if let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError {
+      parts.append("→ underlying: \(describeError(underlying))")
+    }
+    return parts.joined(separator: " ")
   }
 }

--- a/src/ExpoSpotifySDK.types.ts
+++ b/src/ExpoSpotifySDK.types.ts
@@ -48,6 +48,14 @@ export interface SpotifyConfig {
    * `refreshSessionAsync` on both platforms.
    */
   tokenRefreshURL?: string;
+  /**
+   * If `true`, forces Spotify to show the authorization dialog even when
+   * the user already has an active session. Defaults to `false`.
+   *
+   * Maps to `SPTSessionManager.alwaysShowAuthorizationDialog` on iOS and
+   * `AuthorizationRequest.Builder.setShowDialog(true)` on Android.
+   */
+  showDialog?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add an optional `showDialog: boolean` to the `authenticateAsync` config that forces Spotify's authorization dialog to appear even when the user already has an active session. Defaults to `false` so existing behaviour is unchanged.

Maps to `SPTSessionManager.alwaysShowAuthorizationDialog` on iOS (a property on the session manager, not an `SPTAuthorizationOptions` flag) and `AuthorizationRequest.Builder.setShowDialog(boolean)` on Android.

Useful during development to re-prompt for scopes; Spotify recommends against enabling it in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `showDialog` configuration option to the Spotify authentication flow, enabling developers to force the authorization dialog to appear even when users already have an active Spotify session.

* **Documentation**
  * Updated README documentation with details about the new `showDialog` configuration option and its platform-specific behavior across both iOS and Android platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->