### PR TITLE
fix(plugin): change default redirectPathPattern from "/.*" to ".*"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ android {
             spotifyRedirectUri:    "myapp://spotify-auth",
             redirectSchemeName:    "myapp",
             redirectHostName:      "spotify-auth",
-            redirectPathPattern:   "/.*"
+            redirectPathPattern:   ".*"
         ]
     }
 }
@@ -107,14 +107,21 @@ export default {
         clientID: "your-spotify-client-id",
         scheme: "myapp",
         host: "spotify-auth",
-        // Optional: path pattern accepted by the Spotify Android SDK redirect.
-        // Defaults to "/.*" (matches any path). Change this only if you have a
-        // specific redirect path registered in your Spotify app settings.
-        redirectPathPattern: "/.*",
       },
     ],
   ],
 };
+```
+
+`redirectPathPattern` is optional and defaults to `".*"`, which matches every redirect URI shape Spotify will hand back. Only set it if you have a specific path registered in your Spotify app settings:
+
+```ts
+{
+  clientID: "your-spotify-client-id",
+  scheme: "myapp",
+  host: "spotify-auth",
+  redirectPathPattern: "/auth/.*",
+}
 ```
 
 ### Plugin options
@@ -124,7 +131,7 @@ export default {
 | `clientID`            | `string` | ✅       | Your Spotify application's Client ID                       |
 | `scheme`              | `string` | ✅       | URL scheme registered for your app (e.g. `"myapp"`)        |
 | `host`                | `string` | ✅       | Host component of the redirect URI (e.g. `"spotify-auth"`) |
-| `redirectPathPattern` | `string` | —        | Android redirect path regex. Defaults to `"/.*"`           |
+| `redirectPathPattern` | `string` | —        | Android redirect path regex. Defaults to `".*"`            |
 
 The redirect URI registered in your [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) must match `{scheme}://{host}` exactly (e.g. `myapp://spotify-auth`).
 

--- a/plugin/src/__tests__/withSpotifyAndroidAppBuildGradle.test.ts
+++ b/plugin/src/__tests__/withSpotifyAndroidAppBuildGradle.test.ts
@@ -111,9 +111,9 @@ describe("withSpotifyAndroidAppBuildGradle", () => {
       expect(result).toContain('redirectHostName: "callback"');
     });
 
-    it("uses the default redirectPathPattern /.*", () => {
+    it("uses the default redirectPathPattern .*", () => {
       const result = applyPlugin(GRADLE_WITH_DEFAULT_CONFIG);
-      expect(result).toContain('redirectPathPattern: "/.*"');
+      expect(result).toContain('redirectPathPattern: ".*"');
     });
 
     it("uses a custom redirectPathPattern when provided", () => {

--- a/plugin/src/android/withSpotifyAndroidAppBuildGradle.ts
+++ b/plugin/src/android/withSpotifyAndroidAppBuildGradle.ts
@@ -3,7 +3,7 @@ import { ConfigPlugin, withAppBuildGradle } from "@expo/config-plugins";
 import { SpotifyConfig } from "../types";
 
 const SENTINEL_KEY = "spotifyClientId";
-const DEFAULT_REDIRECT_PATH_PATTERN = "/.*";
+const DEFAULT_REDIRECT_PATH_PATTERN = ".*";
 
 export const withSpotifyAndroidAppBuildGradle: ConfigPlugin<SpotifyConfig> = (
   config,

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -34,7 +34,7 @@ export type SpotifyScopes =
  *       clientID: "<spotify-client-id>",
  *       scheme: "myapp",
  *       host: "spotify-auth",
- *       redirectPathPattern: "/.*"
+ *       redirectPathPattern: ".*"
  *     }]
  *   ]
  * }
@@ -51,8 +51,11 @@ export interface SpotifyConfig {
   scheme: string;
   /**
    * Path pattern Spotify will accept on the redirect URI. Required by the
-   * Spotify Android Auth SDK from version 3.0.0 onwards. Defaults to `"/.*"`
-   * which matches any path (preserving pre-3.0.0 SDK behaviour).
+   * Spotify Android Auth SDK from version 3.0.0 onwards. Defaults to `".*"`
+   * which matches any path including the empty string, so it works for both
+   * `scheme://host` and `scheme://host/path` redirect URIs. Use a more
+   * specific pattern (e.g. `"/auth/.*"`) only if you have a specific path
+   * registered in your Spotify app settings.
    *
    * See: https://developer.android.com/guide/topics/manifest/data-element#path
    */


### PR DESCRIPTION
The previous default required at least a literal "/" in the URI path, which fails to match the most common Spotify redirect URI shape "scheme://host" where the path component is the empty string. ".*" matches both empty and non-empty paths, so existing setups that override to a stricter pattern continue to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default Android redirect path pattern to match intended regex behavior.

* **Documentation**
  * Updated Android configuration documentation to reflect the correct default redirect path pattern and provide guidance on using more specific patterns for custom redirect paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->