### PR TITLE
fix: correct SDK_VERSION drift and auto-sync on future releases

### DIFF
--- a/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
@@ -8,7 +8,7 @@ import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
-private const val SDK_VERSION = "0.5.0"
+private const val SDK_VERSION = "0.7.1" // x-release-please-version
 private const val EVENT_SESSION_CHANGE = "onSessionChange"
 
 class ExpoSpotifySDKModule : Module() {

--- a/ios/ExpoSpotifySDKModule.swift
+++ b/ios/ExpoSpotifySDKModule.swift
@@ -1,7 +1,7 @@
 import ExpoModulesCore
 import SpotifyiOS
 
-private let SDK_VERSION = "0.5.0"
+private let SDK_VERSION = "0.7.1" // x-release-please-version
 private let EVENT_SESSION_CHANGE = "onSessionChange"
 
 public class ExpoSpotifySDKModule: Module {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,16 @@
     ".": {
       "release-type": "node",
       "package-name": "@wwdrew/expo-spotify-sdk",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "ios/ExpoSpotifySDKModule.swift"
+        },
+        {
+          "type": "generic",
+          "path": "android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt"
+        }
+      ],
       "changelog-sections": [
         { "type": "feat",     "section": "Features"         },
         { "type": "fix",      "section": "Bug Fixes"        },


### PR DESCRIPTION
ios/ExpoSpotifySDKModule.swift and android/.../ExpoSpotifySDKModule.kt both hardcoded SDK_VERSION = "0.5.0" while the npm package was at 0.7.1. The value flows into the User-Agent header on token swap and refresh requests, so server-side metrics and logs were attributing real 0.7.x traffic to a long-dead version.
Bumps both files to 0.7.1 and adds x-release-please-version inline markers wired into release-please's extra-files so the literals stay in sync with package.json automatically on every future release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * SDK version updated from 0.5.0 to 0.7.1
  * Release configuration updated to track version changes across all platform modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->