### PR TITLE
fix: plumb previous scopes through refreshSessionAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,23 @@ Exchanges a refresh token for a new access token via your token refresh server.
 
 **Parameters:**
 
-| Field             | Type     | Description                                                 |
-| ----------------- | -------- | ----------------------------------------------------------- |
-| `refreshToken`    | `string` | The refresh token from a previous `authenticateAsync` call. |
-| `tokenRefreshURL` | `string` | URL of your token refresh server endpoint.                  |
+| Field             | Type             | Required | Description                                                                                                                                                                              |
+| ----------------- | ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `refreshToken`    | `string`         | ✅       | The refresh token from a previous `authenticateAsync` call.                                                                                                                              |
+| `tokenRefreshURL` | `string`         | ✅       | URL of your token refresh server endpoint.                                                                                                                                               |
+| `scopes`          | `SpotifyScope[]` | —        | Previously-granted scopes. Used as a fallback when the refresh response omits the `scope` field. **Pass through the previous session's `scopes`** to avoid silently losing scope info.   |
 
 **Returns** a fresh `SpotifySession` with an updated `accessToken` and `expirationDate`. If the server rotates the refresh token the new one is returned in `refreshToken`; otherwise the original token is returned so you can continue refreshing.
+
+**Why pass `scopes`:** Spotify's refresh endpoint only returns `scope` when the granted scope set has changed since the last issuance — most refresh responses omit it. Without `scopes` plumbed through, the returned session's `scopes` will be `[]` on every refresh that doesn't include the field, even though the access token itself still carries the same scopes.
+
+```ts
+const refreshed = await refreshSessionAsync({
+  refreshToken: previous.refreshToken,
+  tokenRefreshURL: "https://your-server.example.com/refresh",
+  scopes: previous.scopes,
+});
+```
 
 ---
 

--- a/android/src/main/java/expo/modules/spotifysdk/SpotifyConfig.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/SpotifyConfig.kt
@@ -22,6 +22,7 @@ class SpotifyAuthenticateOptions : Record {
 class SpotifyRefreshOptions : Record {
   @Field val refreshToken: String = ""
   @Field val tokenRefreshURL: String = ""
+  @Field val scopes: List<String> = emptyList()
 }
 
 /**

--- a/ios/ExpoSpotifySDKModule.swift
+++ b/ios/ExpoSpotifySDKModule.swift
@@ -64,7 +64,7 @@ public class ExpoSpotifySDKModule: Module {
         let result = try await client.refresh(
           refreshToken: options.refreshToken,
           tokenRefreshURL: options.tokenRefreshURL,
-          previousScopes: []
+          previousScopes: options.scopes
         )
         let map: [String: Any?] = [
           "accessToken": result.accessToken,
@@ -110,4 +110,5 @@ struct AuthenticateOptions: Record {
 struct RefreshOptions: Record {
   @Field var refreshToken: String = ""
   @Field var tokenRefreshURL: String = ""
+  @Field var scopes: [String] = []
 }

--- a/src/ExpoSpotifySDK.types.ts
+++ b/src/ExpoSpotifySDK.types.ts
@@ -29,6 +29,18 @@ export interface SpotifyRefreshConfig {
   refreshToken: string;
   /** URL of your token refresh server endpoint. */
   tokenRefreshURL: string;
+  /**
+   * Scopes that were granted by the previous session. Used as a fallback
+   * when the refresh response omits the `scope` field (which most
+   * `accounts.spotify.com` refresh responses do — Spotify only returns
+   * `scope` when the granted scope set has changed).
+   *
+   * If omitted, the returned `SpotifySession.scopes` will be `[]` whenever
+   * the refresh response also omits `scope` — silently losing scope
+   * information you held a moment ago. Pass through the previous session's
+   * `scopes` to avoid that.
+   */
+  scopes?: SpotifyScope[];
 }
 
 /**


### PR DESCRIPTION
Spotify's refresh endpoint only returns the `scope` field when the granted scope set has changed since the last issuance — most refresh responses omit it. Both natives were hardcoding the fallback as an empty list, which meant that any refresh-without-scope returned a SpotifySession with `scopes: []` even though the access token still carried the same scopes. Silent data loss.

Add an optional `scopes` field to SpotifyRefreshConfig and plumb it through both natives' refresh paths so callers can pass the previous session's scopes through. Existing call sites continue to work but are now explicitly opting into the lossy behaviour by omitting it; the README documents the recommended pattern.