### PR TITLE
fix: classify Android EMPTY auth response as USER_CANCELLED

### DIFF
--- a/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
@@ -122,8 +122,8 @@ class ExpoSpotifySDKModule : Module() {
             )
           }
           AuthorizationResponse.Type.CANCELLED -> throw UserCancelledException()
-          AuthorizationResponse.Type.EMPTY -> throw UnknownSpotifyException(
-            "Spotify returned an empty response (auth activity may have been killed)",
+          AuthorizationResponse.Type.EMPTY -> throw UserCancelledException(
+            "Spotify returned an empty response (auth activity dismissed before completion)",
           )
           AuthorizationResponse.Type.ERROR -> throw SpotifyAuthErrorException(
             response.error ?: "Spotify returned an unspecified error",
@@ -153,7 +153,7 @@ class ExpoSpotifySDKModule : Module() {
         val payload = client.refresh(
           refreshToken = options.refreshToken,
           tokenRefreshURL = options.tokenRefreshURL,
-          previousScopes = emptyList(),
+          previousScopes = options.scopes,
         )
         emitSession("didRenew", payload)
         payload.toMap()


### PR DESCRIPTION
When the Spotify Android auth activity is dismissed before completing (user backs out, swipes home, kills the activity), the Spotify SDKreturns AuthorizationResponse.Type.EMPTY. The module was reporting thisas UNKNOWN, which surfaces as a generic error in callers' UIs eventhough it's a perfectly normal user-cancellation.

Reclassify as USER_CANCELLED so callers' existing cancellation handling(typically: silent dismissal, no error UI) treats it correctly. Matchesthe behaviour of CANCELLED already, and is consistent with the iOSside, which produces userCancelled for the same gesture.