### PR TITLE
fix(ios): escape "+" in form-encoded refresh token bodies

### DIFF
--- a/ios/SpotifyTokenRefreshClient.swift
+++ b/ios/SpotifyTokenRefreshClient.swift
@@ -113,6 +113,9 @@ struct SpotifyTokenRefreshClient {
   private func formURLEncoded(_ pairs: [String: String]) -> String {
     var components = URLComponents()
     components.queryItems = pairs.map { URLQueryItem(name: $0.key, value: $0.value) }
-    return components.percentEncodedQuery ?? ""
+    // `URLComponents.percentEncodedQuery` does NOT escape `+`, but in
+    // `application/x-www-form-urlencoded` bodies `+` means space. Replace it
+    // explicitly so refresh tokens containing `+` survive the round-trip.
+    return (components.percentEncodedQuery ?? "").replacingOccurrences(of: "+", with: "%2B")
   }
 }


### PR DESCRIPTION
`URLComponents.percentEncodedQuery` does not escape `+`, but in `application/x-www-form-urlencoded` bodies `+` is interpreted as a space. If a refresh token (or any future field) ever contains `+`, the server would receive a corrupted value.


Spotify's current token format is base64url so this hasn't bittenanyone in practice, but the Foundation gotcha is well known and thefix is a one-liner. Android uses OkHttp's `FormBody.Builder` whichalready encodes correctly, so no change needed there.