### PR TITLE
fix(ios): log unknown scope strings instead of silently dropping them

### DIFF
--- a/ios/SPTScopeSerializer.swift
+++ b/ios/SPTScopeSerializer.swift
@@ -38,6 +38,11 @@ enum SPTScopeSerializer {
     for string in scopes {
       if let value = lookup[string] {
         result.insert(value)
+      } else {
+        // Unknown scope strings are silently dropped by the Spotify iOS SDK,
+        // which can quietly change the meaning of a caller's request. Surface
+        // it so it's debuggable from the device console.
+        NSLog("[ExpoSpotifySDK] Unknown scope dropped: %@", string)
       }
     }
     return result


### PR DESCRIPTION
`SPTScopeSerializer.deserialize` skipped scope strings that weren't in its hard-coded map, which meant a typo or a newly-added Spotify scope silently changed the meaning of a caller's auth request. Android forwards scope strings raw and lets Spotify reject them, so the two platforms diverged in observable behaviour.


Keep the lenient drop (changing it to a hard error would be a breaking change) but `NSLog` each unknown scope so the discrepancy is at leastdebuggable from the device console.