### PR TITLE
docs: add initial ADRs

### DIFF
--- a/docs/adr/0001-build-time-download-of-spotify-native-sdks.md
+++ b/docs/adr/0001-build-time-download-of-spotify-native-sdks.md
@@ -1,0 +1,157 @@
+# ADR-0001: Build-Time Download of Spotify Native SDKs
+
+- **Status:** Proposed
+- **Date:** 2026-05-07
+- **Deciders:** @wwdrew
+
+## Context
+
+This library is an Expo module that wraps Spotify's native iOS and Android SDKs to provide OAuth authentication (and, in a follow-up, App Remote playback control) inside React Native / Expo apps.
+
+Spotify ships its native SDKs through unusual channels:
+
+| Platform | SDK | How Spotify distributes it |
+| --- | --- | --- |
+| iOS | `SpotifyiOS.xcframework` | Checked into [`github.com/spotify/ios-sdk`](https://github.com/spotify/ios-sdk) at the repo root. Releases tag the repo but **publish no asset binaries** (`assets: []`). A `Package.swift` declares a local-path `binaryTarget`, so SPM consumers clone the whole repo. **Not on CocoaPods.** |
+| Android (Auth) | `com.spotify.android:auth` | Officially published to **Maven Central** (latest at time of writing: `4.0.1`, 2026-03-04). |
+| Android (App Remote) | `spotify-app-remote-release-<version>.aar` | Direct asset on [`github.com/spotify/android-sdk` releases](https://github.com/spotify/android-sdk/releases). Not on Maven Central. Tag scheme is irregular: `v0.8.0-appremote_v2.1.0-auth`. |
+
+### Today's integration
+
+- **iOS:** `SpotifyiOS.xcframework` (~1.2 MB) is checked into this repo at `ios/SpotifySDK/SpotifyiOS.xcframework/` and shipped inside the npm tarball. The podspec wires it via `s.vendored_frameworks`.
+- **Android:** Only the auth library is integrated. `android/build.gradle` declares `implementation "com.spotify.android:auth:4.0.1"` from Maven Central. App Remote is not yet supported.
+- **README:** Tells consumers to add `implementation 'com.spotify.android:auth:4.0.1'` to *their* `app/build.gradle` themselves — a leaky abstraction.
+
+### Problems with today's setup
+
+1. **Legal / redistribution exposure.** We are republishing Spotify's binary framework via npm without a license that authorises redistribution. The xcframework is licensed for use, not for downstream re-bundling.
+2. **Repository bloat.** Every Spotify SDK upgrade produces a binary diff. Every clone pays the 1.2 MB cost forever.
+3. **NPM tarball bloat.** The framework ships in every `npm install`, even for users who never build for iOS.
+4. **Manual upgrade churn.** Bumping the iOS SDK means downloading Spotify's source, copying files in, and committing a binary. There is no `npm update`-style flow.
+5. **No App Remote support.** Adding it today would require either vendoring another binary (compounding problems 1–3) or designing a download mechanism — which we may as well design once and apply to both platforms.
+6. **Consumer setup leakage.** Consumers wire the Android auth dep themselves, even though it's an internal implementation detail of this module.
+
+### Constraints
+
+- **No redistribution.** Spotify binaries must not live in our git history nor in our npm tarball.
+- **Build-time download, not install-time.** Pulling at `npm install` ties network access to package install and breaks `npm ci` in offline-cached CI layers. Acceptable failure modes: `pod install` and `gradle build` requiring network on a clean checkout.
+- **Pinned versions with integrity verification.** Reproducible builds. SHA-256 mismatch = build fails.
+- **No new tooling demanded of consumers.** No `gem install …` step, no extra Gradle plugins to learn, no extra Podfile boilerplate beyond what `expo prebuild` already produces.
+- **Works on Expo SDK 54+ / RN 0.81+** (the example app's current target).
+
+## Decision
+
+We will **stop vendoring Spotify binaries** and pull them at build time, using each platform's first-class extension points.
+
+### iOS — `prepare_command` in the podspec
+
+The podspec at `ios/ExpoSpotifySDK.podspec` will gain a `prepare_command` block that runs at `pod install` time. It will:
+
+1. Read pinned constants `SPOTIFY_IOS_SDK_VERSION` and `SPOTIFY_IOS_SDK_TARBALL_SHA256` declared at the top of the podspec.
+2. Skip if `ios/SpotifySDK/.version` matches `SPOTIFY_IOS_SDK_VERSION` and `ios/SpotifySDK/SpotifyiOS.xcframework/` already exists (idempotent / cached).
+3. Otherwise download `https://github.com/spotify/ios-sdk/archive/refs/tags/v<version>.tar.gz` to a temp dir.
+4. Verify SHA-256 against the pinned constant. Mismatch fails the build.
+5. Extract `SpotifyiOS.xcframework/` and `Licenses/` into `ios/SpotifySDK/`.
+6. Write `ios/SpotifySDK/.version` for cache invalidation.
+
+The existing `s.vendored_frameworks = "SpotifySDK/SpotifyiOS.xcframework"` line is unchanged — the framework is just on-demand instead of vendored.
+
+### Android — Custom download task + `flatDir` for App Remote
+
+In `android/build.gradle`:
+
+1. **Auth library: no change.** Keep `implementation "com.spotify.android:auth:<version>"` resolving from Maven Central.
+2. **App Remote:** add a `downloadSpotifyAppRemote` Gradle task that runs at configuration time. It will:
+   - Read pinned constants `SPOTIFY_APP_REMOTE_VERSION`, `SPOTIFY_APP_REMOTE_TAG`, `SPOTIFY_APP_REMOTE_SHA256`.
+   - Download `https://github.com/spotify/android-sdk/releases/download/<tag>/spotify-app-remote-release-<version>.aar` into `$buildDir/spotify-app-remote/` if not already cached, verifying SHA-256.
+3. Wire `preBuild.dependsOn downloadSpotifyAppRemote`.
+4. Add a `flatDir { dirs ... }` repository pointing at `$buildDir/spotify-app-remote/`.
+5. Add `implementation name: "spotify-app-remote-release-<version>", ext: "aar"`.
+
+### Versioning policy
+
+Pinned constants live in **this** package's build configs (podspec + `build.gradle`). One spot to update on upgrades. Bumping a Spotify SDK version becomes:
+
+1. Change two constants and two SHAs in this repo.
+2. Ship a new patch release of `@wwdrew/expo-spotify-sdk`.
+
+Consumers do **not** override Spotify SDK versions independently of this library's version. Doing so is unsupported because untested combinations risk silent breakage and become unactionable bug reports.
+
+### Internalising the Android auth dependency
+
+The README's "consumer setup" section will stop instructing users to add `implementation 'com.spotify.android:auth:…'` to their app's `build.gradle`. The dependency already lives in our `android/build.gradle` as `implementation` — it transits to consumers via Gradle's normal dependency resolution. The manifest placeholders (`spotifyClientId`, `spotifyRedirectUri`, etc.) remain in the consumer's `build.gradle`, injected by the existing config plugin.
+
+## Alternatives Considered
+
+### iOS
+
+| Alternative | Verdict | Reason |
+| --- | --- | --- |
+| `cocoapods-spm` plugin (`s.spm_dependency` in podspec, `spm_pkg` in Podfile) | **Rejected** | Niche third-party gem (97⭐, single maintainer). Imposes a `gem install cocoapods-spm` step on every consumer. Too much friction for a published library. |
+| Native Expo SDK 54 SPM support (PR [expo/expo#44248](https://github.com/expo/expo/commit/6aec778139dbbd89af2f2cc58362abb160ac8249)) | **Rejected for now** | Brand new (March 2026), not yet broadly battle-tested for binary `.xcframework` deps in third-party Expo modules. Revisit when stable. |
+| `withDangerousMod` config plugin downloading into the consumer's `ios/` tree | **Rejected** | Wrong layer. Bakes timing into `expo prebuild`, fights `expo prebuild --clean`, doesn't run on subsequent `pod install`s, and contaminates the consumer's source tree with files we own. |
+| Xcode build-phase script | **Rejected** | Cannot `vendored_frameworks` a path that doesn't exist at podspec-evaluation time. Linking fails before the script runs. |
+| NPM `postinstall` script | **Rejected** | Install-time, not build-time. Breaks `npm ci` in offline / cached CI layers. Explicit constraint. |
+| Status quo (vendor the binary) | **Rejected** | The driving motivation for this ADR. |
+
+### Android
+
+| Alternative | Verdict | Reason |
+| --- | --- | --- |
+| `ivy {}` repository with `patternLayout` mapping App Remote to GitHub Releases | **Rejected** | Spotify's tag scheme bakes both the App Remote version and the unrelated Auth version into the same string (`v0.8.0-appremote_v2.1.0-auth`). The ivy pattern would require hard-coding the Auth version portion, creating a brittle coupling that doesn't actually exist in the artifact. |
+| `de.undercouch.download` Gradle plugin | **Rejected** | Adds a buildscript dependency for what is effectively five lines of `ant.get` or `URL.openStream`. Overkill. |
+| Vendoring the App Remote `.aar` in this repo | **Rejected** | Same redistribution / bloat problem as the iOS xcframework. |
+| Status quo (no App Remote) | **Rejected** | Blocks the next phase of work. |
+
+## Consequences
+
+### Positive
+
+- 1.2 MB Spotify binary leaves the git history (after `git filter-repo` or equivalent on the next major release; alternatively, leave history and just stop adding to it).
+- Zero Spotify binaries in the npm tarball.
+- No "redistributing someone else's licensed binary" exposure — both binaries come straight from `github.com/spotify/...` under Spotify's own hosting at build time.
+- Pinned versions + SHAs = reproducible, auditable builds. Supply-chain compromise of the GitHub asset would fail SHA verification.
+- Bumping the Spotify SDK becomes a tiny, reviewable PR (two constants + two SHAs).
+- App Remote support unblocked — same mechanism, additional pinned constants.
+- Consumer setup simplifies: no manual Gradle `implementation` line, no manual Podfile additions.
+
+### Negative
+
+- **First-time clean build requires network access** for both `pod install` and `gradle build`. CI runners without internet for these steps will fail. (In practice, all CI that builds RN apps already needs network access for npm and Maven Central, so this is a non-change.)
+- **GitHub Releases availability is now a runtime build-time dependency.** If `github.com` is unreachable or Spotify deletes a release tag, builds break. Mitigation: SHAs are pinned and binaries are typically already cached in `Pods/` or `$buildDir/` between builds.
+- **`prepare_command` runs every `pod install`** and pays the cache-check overhead. Tiny, but non-zero.
+- **The `prepare_command` pattern is mildly discouraged by CocoaPods docs** in favour of `s.source = { :http => ... }`. We can't use `s.source` because our pod's source IS this repo's Swift code, not the Spotify framework. Many real-world podspecs do exactly what we're doing; the guidance is more conventional than prohibitive.
+- **One-time CHANGELOG note required**: bumping past this ADR is a behaviour change for consumers (first build is slower; offline first-build-after-clone fails). Document in the release notes.
+
+### Neutral
+
+- Android Auth library remains on Maven Central. We do not switch it to a GitHub-Releases download for "consistency" — Maven Central is canonical, official, and well-cached on every Gradle install.
+- The Expo config plugin keeps the Android manifest-placeholder injection logic; we are not replacing it.
+
+## Implementation Sketch
+
+| File | Change |
+| --- | --- |
+| `ios/SpotifySDK/SpotifyiOS.xcframework/` | **Delete** (1.2 MB out of repo) |
+| `ios/SpotifySDK/.gitignore` | Add `SpotifyiOS.xcframework/`, `.version`, `Licenses/` |
+| `.gitignore` (root) | Add `ios/SpotifySDK/SpotifyiOS.xcframework/`, `ios/SpotifySDK/.version`, `ios/SpotifySDK/Licenses/` |
+| `ios/ExpoSpotifySDK.podspec` | Add `SPOTIFY_IOS_SDK_VERSION` + `..._SHA256` constants, add `prepare_command` block |
+| `android/build.gradle` | Add `SPOTIFY_APP_REMOTE_VERSION` + `..._TAG` + `..._SHA256` constants, `downloadSpotifyAppRemote` task, `flatDir` repo, `preBuild.dependsOn`, App Remote `implementation` line |
+| `README.md` | Remove "add `implementation 'com.spotify.android:auth'` to your `app/build.gradle`" section. Add a note that the first build requires network access. |
+| `CONTRIBUTING.md` | Document how to bump Spotify SDK versions (compute new SHA via `shasum -a 256`, update constants, regenerate fixture if any). |
+| `.npmignore` | Confirm `ios/SpotifySDK/SpotifyiOS.xcframework/` is excluded (defensive). |
+
+## Open Questions
+
+- Should we ship a **fallback** for the rare case where a developer's machine cannot reach `github.com` at build time (e.g. behind a corporate proxy)? Possible mitigation: an env var (`SPOTIFY_IOS_SDK_LOCAL_PATH`) that lets advanced users point at a pre-downloaded copy. Defer until we hit a real user reporting this.
+- Should we publish a **GitHub Action** that bumps Spotify SDK versions automatically (Renovate-style, pinned by tag)? Defer until manual bumps become a recurring chore.
+
+## Validation
+
+Before merging the implementation PR, verify:
+
+1. `npm pack --dry-run` shows no `*.xcframework` entries in the tarball file list.
+2. From a clean checkout: `cd example && npx expo prebuild --clean && pod install && pod install` (twice) — second run is a no-op, no re-download.
+3. `cd example && npx expo run:ios` succeeds; OAuth flow works end-to-end.
+4. `cd example && npx expo run:android` succeeds; OAuth flow works end-to-end.
+5. Tamper test: temporarily change one byte of the pinned SHA in either build config; confirm the build fails with a clear "checksum mismatch" error rather than silently using a wrong binary.

--- a/docs/adr/0002-auto-cancel-stale-pending-auth.md
+++ b/docs/adr/0002-auto-cancel-stale-pending-auth.md
@@ -1,0 +1,170 @@
+# ADR-0002: Auto-Cancel Stale Pending Auth on iOS
+
+- **Status:** Proposed
+- **Date:** 2026-05-07
+- **Deciders:** @wwdrew
+
+## Context
+
+`SpotifyAuthCoordinator` on iOS holds a single `CheckedContinuation` (`pending`) for the in-flight `authenticateAsync` call. The contract is "one auth at a time": a second call while `pending != nil` rejects with `AUTH_IN_PROGRESS`. The `pending` slot is cleared when `SPTSessionManagerDelegate` fires `didInitiate(_:)` or `didFailWith:`.
+
+ADR-0001 isn't relevant to this decision; the area in scope is `ios/SpotifyAuthCoordinator.swift` and the JS-layer wrapper.
+
+### Today's behaviour (post v0.7.x)
+
+After the leaked-continuation fix shipped in v0.7.x:
+
+- `cancelPendingAuthAsync()` is exposed on the JS API. It resumes the continuation with `userCancelled` and clears `pending`.
+- The recommended consumer pattern (documented in `README.md`) is to call `cancelPendingAuthAsync()` defensively before every `authenticateAsync()`, on the assumption that the previous attempt may have leaked.
+- Android is unaffected: `SpotifyAuthCoordinator.kt` uses a `Mutex` held across `launcher.launch(input)`, and structured concurrency releases the lock when the activity-result coroutine returns. There is no equivalent "leaked state" failure mode on Android.
+
+### Why iOS leaks
+
+`SPTSessionManager` is not guaranteed to fire its delegate. Concrete cases observed in production:
+
+- Network/DNS failure between the app and Spotify (`tokenSwapURL` unreachable). Spotify's web view bounces, the auth never returns to us, no delegate fires.
+- User opens the Spotify app, backgrounds, force-quits Spotify without completing.
+- iOS scene-graph edge cases where the redirect URL is delivered to a scene we don't observe.
+
+In each case, `pending` stays set forever and every subsequent `authenticateAsync()` rejects with `AUTH_IN_PROGRESS` until the app process is killed.
+
+### The constraint nobody outside the SDK can see
+
+When we "cancel" a pending continuation, **we do not actually stop `SPTSessionManager`.** There is no public API for that. All we do is:
+
+1. Resume our continuation with `userCancelled`.
+2. Clear our reference to the continuation.
+
+If the underlying Spotify auth flow was actually still progressing — e.g. the user is mid-login in the Spotify app — and it completes after we've already cancelled, the delegate fires `didInitiate(_:)` with a real session. `pending == nil` at that point, so `deliver(.success(...))` silently does nothing. **We drop a valid session on the floor.**
+
+### Why "always auto-cancel on next authenticate()" is wrong
+
+Naive auto-cancel — "if `pending != nil`, cancel it and proceed" — turns every accidental double-call (button double-tap, `useEffect` retry loop) into a session-discarding event:
+
+1. User taps Connect Spotify. Coordinator sets `pending`. Spotify app opens. User starts logging in.
+2. A re-render fires the second `authenticateAsync()` call. Coordinator cancels `pending` (resumes with `userCancelled`), sets a new `pending`, and redundantly calls `initiateSession` again.
+3. User finishes login in Spotify. Spotify SDK fires `didInitiate(_:)`. The bridge's `Task { await coordinator?.deliver(.success(session)) }` runs. `pending` still refers to the second call's continuation, but the session was triggered by the first call. We resolve the wrong continuation. (At best, this works by accident; at worst, the second `initiateSession` has different scopes/options and the delivered session doesn't match what the second caller asked for.)
+
+In short: with no real ability to interrupt `SPTSessionManager`, **time-of-receipt vs time-of-initiation become decoupled**, and any naive cancel-on-reentry policy mismatches sessions to callers.
+
+### What signals can we trust
+
+Two signals indicate that a pending continuation is **almost certainly** abandoned by the underlying SDK and safe to cancel:
+
+1. **Age.** Spotify auth completes (success or failure) in seconds in the success path, and fails fast on most error paths (network, no Spotify app installed, user cancellation in Spotify). A `pending` older than ~60s is overwhelmingly likely to be a leak, not a user still logging in.
+2. **App foreground transition without an inbound URL.** If the user backgrounded our app to the Spotify auth flow and returned to our app without us receiving a redirect URL, the auth flow is dead from our side regardless of what `SPTSessionManager` thinks. (This is the same signal browsers use to time out OAuth popup flows.)
+
+Either signal alone is conservative; together they cover both leak shapes seen in production.
+
+## Decision
+
+We will **auto-cancel stale pending auth** on `authenticateAsync()` re-entry, using a staleness predicate combining age and foreground-without-redirect.
+
+### Coordinator changes
+
+`SpotifyAuthCoordinator` gains:
+
+- `pendingStartedAt: Date?` — set alongside `pending`, cleared alongside it.
+- `pendingFlowSawForeground: Bool` — set to `true` if the app foregrounds while `pending != nil`. Reset to `false` whenever a new `pending` is set, and we observe `UIApplication.didBecomeActiveNotification`.
+- `handleOpenURL(_:options:)` clears `pendingFlowSawForeground` (a redirect arrived → not a leak yet).
+
+`authenticate(...)` decision tree:
+
+```text
+if pending == nil → proceed (set pendingStartedAt = now)
+else:
+  if isStalePending() → cancelPending() with reason `.timedOut`; proceed
+  else → throw .authInProgress
+```
+
+`isStalePending()` returns `true` if either:
+
+- `pendingStartedAt` is older than `pendingStaleThreshold` (default: 60 seconds), or
+- `pendingFlowSawForeground == true`.
+
+### New error case: `pendingTimedOut`
+
+`SpotifyError` gains a case `pendingTimedOut` with code `AUTH_TIMED_OUT`, distinct from `userCancelled`. Used both:
+
+- when `cancelPending()` is invoked by the staleness path (so the prior caller's promise rejects with a meaningful reason rather than a generic cancellation), and
+- as a new public error code on the JS taxonomy (`SpotifyErrorCode = ... | "AUTH_TIMED_OUT"`).
+
+This matters because `userCancelled` already has UX meaning ("the user explicitly cancelled"), and we should not lie to consumers' analytics by reporting timeouts as cancellations.
+
+### `cancelPendingAuthAsync()` is no longer required, but is retained
+
+The JS API stays. Removing it would break consumers who already call it on their critical path, and there are legitimate uses (deterministic teardown in tests; explicit "user navigated away, kill any pending flow"). Documentation will:
+
+- Stop recommending it as a defensive preflight before every `authenticateAsync()`.
+- Explain the new auto-cancel behaviour and that the preflight is now redundant.
+- Keep `cancelPendingAuthAsync` documented as the explicit escape hatch.
+
+### Configurability
+
+`pendingStaleThreshold` is a coordinator-level constant, not an `authenticateAsync()` parameter. Reasoning: this is a leak-recovery threshold, not a per-call timeout. Per-call timeouts are a different feature (see Open Questions) and would compose with this, not replace it.
+
+### Android
+
+No change. The `Mutex`-based coordinator already releases on coroutine cancellation / activity-result return, so there is no analogous leak.
+
+## Alternatives Considered
+
+| Alternative | Verdict | Reason |
+| --- | --- | --- |
+| Status quo (manual `cancelPendingAuthAsync` preflight from JS) | **Rejected** | Footgun. Every consumer must learn this pattern; forgetting it strands the user in `AUTH_IN_PROGRESS` purgatory. |
+| Always auto-cancel on re-entry (no staleness check) | **Rejected** | Drops legitimate sessions when callers race. See "Why naive auto-cancel is wrong" above. |
+| Time-only staleness (no foreground signal) | **Rejected for primary, retained as fallback** | Catches the "user came back five minutes later" case but waits 60s to recover even when the app foregrounded with no redirect — which is *immediate* evidence of a leak. |
+| Foreground-only staleness (no time threshold) | **Rejected** | Sufficient for the in-process leak cases observed today, but the time threshold is cheap defence-in-depth and useful in headless contexts (tests, scene configurations where the active-notification doesn't fire as expected). |
+| Per-call timeout (`authenticateAsync({ timeoutMs })`) | **Deferred** | Composes with this design rather than replacing it. Worth doing later if consumers want bounded UX (e.g. show their own error after 30s) but does not solve leak recovery on its own. |
+| Reach into `SPTSessionManager` to actually cancel its in-flight flow | **Rejected** | No public API. Reflection / private-API access disqualifies the SDK from App Store review. |
+| Replace `SPTSessionManager` with a custom auth flow (PKCE in `ASWebAuthenticationSession`) | **Rejected for this ADR** | Materially larger scope. Worth its own ADR if we ever want to drop SPT for auth, but unrelated to leak recovery. |
+
+## Consequences
+
+### Positive
+
+- The most common leak mode ("Spotify never redirected back, user retried") is recovered transparently. Consumers no longer need to know about `cancelPendingAuthAsync`.
+- The Songkick-mobile-style preflight pattern can be removed from consumer code without regression.
+- Genuine double-tap races within 60s (and before app foreground) still get `AUTH_IN_PROGRESS`, which is the correct signal for "you have a UI bug, debounce your button." Auto-cancel doesn't paper over those.
+- New `AUTH_TIMED_OUT` error code lets consumers distinguish leak-recovery from user-initiated cancellation in analytics and error reporting.
+
+### Negative
+
+- Adds lifecycle-observer wiring to the coordinator (`UIApplication.didBecomeActiveNotification`). Modest complexity; tested in isolation.
+- The staleness threshold is a magic number. 60 seconds is defensible but arbitrary — too long for impatient users, too short for slow networks. Mitigation: leave it adjustable in code if real consumer feedback suggests tuning.
+- Adds a new public error code, which is technically a non-breaking additive change but expands the taxonomy consumers must handle. Mitigation: README documents it; default catch-all paths still work because the code is a string.
+- Theoretical lost-session race shrinks but doesn't disappear: if SPTSessionManager genuinely completes auth in the few-millisecond window after `cancelPending()` runs but before the new `initiateSession()` is dispatched, we still drop the session. The probability is low (the user would have to complete login in Spotify in <1ms across a process boundary), but it exists. Acceptable given the alternative is the existing leak.
+
+### Neutral
+
+- Android coordinator unchanged — no Android-side complexity added.
+- `cancelPendingAuthAsync` JS API retained — no breaking change for current consumers.
+- The diagnostic logging added in v0.7.x (`NSLog` of error codes in the bridge) is unaffected and remains useful.
+
+## Implementation Sketch
+
+| File | Change |
+| --- | --- |
+| `ios/SpotifyAuthCoordinator.swift` | Add `pendingStartedAt`, `pendingFlowSawForeground`, `pendingStaleThreshold` (default 60s). New `isStalePending()` predicate. `authenticate(...)` consults it before throwing `authInProgress`. Add `case pendingTimedOut` to `SpotifyError`. Hook `UIApplication.didBecomeActiveNotification` (via a small `NSObject` observer; the actor itself can't be the observer). Reset `pendingFlowSawForeground = false` when `handleOpenURL` is called. |
+| `src/ExpoSpotifySDK.types.ts` | Add `"AUTH_TIMED_OUT"` to `SpotifyErrorCode`. |
+| `src/index.ts` | No surface change; the new code rides through the existing `SpotifyError` mapping. |
+| `README.md` | Update "Recovery from stuck auth state" section: remove the "always call `cancelPendingAuthAsync()` first" recommendation; document the new auto-recovery and the `AUTH_TIMED_OUT` code. Keep `cancelPendingAuthAsync` as documented escape hatch. |
+| `CHANGELOG.md` | Document the new behaviour and the new error code. Note that consumers who relied on the preflight pattern can remove it (non-breaking; the call becomes a no-op). |
+
+## Open Questions
+
+- **Should `pendingStaleThreshold` be configurable from JS?** Probably not in this ADR — overrideable defaults invite per-app drift. If a consumer asks, expose it as a module-level setter; until then, hard-coded.
+- **Should we add `authenticateAsync({ timeoutMs })` for explicit per-call timeouts?** Out of scope here. Worth considering as a follow-up if consumers want a way to surface "still waiting" UX before the 60s staleness window.
+- **Should `SpotifyError.pendingTimedOut` carry the prior caller's start timestamp?** Useful for diagnostics if we surface it in the JS error. Defer until a consumer asks; trivially additive.
+- **Is the foreground signal flaky on iPad split-view / scene-aware apps?** `didBecomeActiveNotification` fires per scene activation. We can be conservative and treat any active-notification as "user came back," accepting that in scene-rich apps we may auto-cancel slightly more eagerly than necessary. Worth instrumenting in v1 of the implementation rather than designing around it speculatively.
+
+## Validation
+
+Before merging the implementation PR, verify on a real iOS device:
+
+1. **Happy path unchanged.** `authenticateAsync()` succeeds normally; no spurious `AUTH_TIMED_OUT`.
+2. **Genuine double-tap rejection.** Two `authenticateAsync()` calls fired within 100ms still yield `AUTH_IN_PROGRESS` for the second.
+3. **Time-based recovery.** Trigger a leaked continuation (e.g. start auth, kill network mid-flow, wait 90s, retry). Second call succeeds; first promise rejects with `AUTH_TIMED_OUT`.
+4. **Foreground-based recovery.** Start auth, switch to Spotify, force-quit Spotify, return to our app. Retry within <60s should succeed (foreground signal kicks in before time threshold).
+5. **No dropped sessions in the common race.** Tap Connect Spotify, immediately tap again (within ~200ms). Complete auth in Spotify. The session is delivered to one of the two callers (whichever's continuation is current); neither reports `AUTH_TIMED_OUT`.
+6. **`cancelPendingAuthAsync` still works.** Explicit calls still resume `pending` with `userCancelled` (NOT `AUTH_TIMED_OUT`), preserving the user-initiated semantic.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved iOS authentication handling: stale pending authentication attempts are now automatically cancelled and retried without manual intervention.
  * Added new error type for authentication timeout scenarios.

* **Documentation**
  * Added architectural decision records documenting SDK build process optimization and authentication flow improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wwdrew/expo-spotify-sdk/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->