### PR TITLE
fix(ios): bridge structured SpotifyError code and reason through to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,31 @@ try {
       case "TOKEN_SWAP_PARSE_ERROR": // swap server returned invalid JSON
       case "SPOTIFY_NOT_INSTALLED": // Spotify app not found (rare — most flows fall back to web)
       case "AUTH_ERROR": // Spotify returned an error (e.message has detail)
-      case "UNKNOWN": // unexpected failure
+      case "UNKNOWN": // unexpected failure — e.message has full diagnostics
         reportError(e);
     }
   }
 }
 ```
+
+`e.message` is the structured reason from the native module (not the
+expo-modules-core function-call wrapper text). For `UNKNOWN` failures on
+iOS, the message is the underlying `NSError` chain rendered as
+`"<domain> code <n> \"<localizedDescription>\" → underlying: <…>"`,
+covering the common-but-historically-opaque cases:
+
+- `NSURLErrorDomain` code `-1200` — TLS handshake failure (e.g. an
+  HTTPS-intercepting debug proxy without a trusted root cert) to your
+  `tokenSwapURL`.
+- `SPTErrorDomain` codes — surfaced by the Spotify iOS SDK itself.
+- `kCFErrorDomainCFNetwork` codes — lower-level networking errors.
+
+The original `NSError` is also attached as `e.cause` so Sentry / debug
+breadcrumbs see the full underlying chain, not just the rendered string.
+
+On Android the same field carries the `CodedException`'s `localizedMessage`
+from the corresponding cause path (e.g. `IOException` from the token
+swap call).
 
 ## Android implicit (TOKEN) flow is not recommended
 

--- a/docs/adr/0003-structured-exception-bridging.md
+++ b/docs/adr/0003-structured-exception-bridging.md
@@ -1,0 +1,236 @@
+# ADR-0003: Structured Exception Bridging to JS
+
+- **Status:** Accepted
+- **Date:** 2026-05-11
+- **Deciders:** @wwdrew
+
+## Context
+
+`authenticateAsync` and `refreshSessionAsync` reject with a `SpotifyError`
+carrying a `SpotifyErrorCode` and a human-readable `message`. This is the
+public contract (`src/ExpoSpotifySDK.types.ts`, README "SpotifyError"
+section); consumers branch on `e.code` and surface `e.message` to error
+reporting.
+
+The contract is honoured on Android. It was being silently broken on iOS.
+
+### What was happening on iOS (pre-0.9)
+
+`ios/ExpoSpotifySDKModule.swift` caught `SpotifyError` / `SpotifyRefreshError`
+and re-threw across the JS bridge like this:
+
+```swift
+throw GenericException("\(error.code): \(error.message)")
+```
+
+`GenericException<String>` stores its argument in `param: String` but does
+**not** override `Exception.reason`, which defaults to the literal string
+`"undefined reason"`. The `expo-modules-core` `AsyncFunction` machinery then
+wraps the thrown exception in `FunctionCallException`, whose JS-facing
+description is:
+
+```text
+Calling the '<fn>' function has failed
+→ Caused by: <cause.reason>
+```
+
+…and whose `code` is `cause.code`. Because the cause was a bare
+`GenericException` with no overrides, JS received:
+
+- `err.code = "ERR_GENERIC"` (derived from the class name)
+- `err.message = "Calling the 'authenticateAsync' function has failed\n→ Caused by: undefined reason"`
+
+The structured `SpotifyError.code` ("`USER_CANCELLED`", "`UNKNOWN`", etc.)
+and the underlying SDK message (the iOS coordinator's `describeError` output
+with the full `NSError` chain) were **dropped on the floor** between Swift
+and JS. The `rethrowAsSpotifyError` helper in `src/index.ts` worked around
+this with a regex that scanned `err.message` for a leading `"CODE: msg"`
+prefix — which the buggy wrap never produced — and always fell through to
+`SpotifyError("UNKNOWN", "Calling the '…' function has failed")`.
+
+Net effect: every iOS failure that wasn't a clean
+`USER_CANCELLED`/`AUTH_IN_PROGRESS` path arrived in consumer code as
+`{ code: "UNKNOWN", message: "Calling the 'authenticateAsync' function has failed" }`,
+with the actual cause only visible via `NSLog` in Xcode console.
+
+### What Android does
+
+`android/.../ExpoSpotifySDKModule.kt` throws `CodedException(code, message, cause)`
+directly. `expo-modules-core` Kotlin wraps it in `DecoratedException` (the
+analog of iOS's `FunctionCallException`), which **does** override `code` to
+return `cause.code` and renders `message` as
+`"Call to function '<module>.<fn>' has been rejected.\n→ Caused by: <cause.message>"`.
+
+So the structured code reaches JS correctly on Android; the visible wrapper
+prefix differs from iOS but the canonical `→ Caused by:` separator (with a
+trailing space) is the same.
+
+## Decision
+
+We will bridge each platform's structured error type through a thin
+`Exception` / `CodedException` subclass that explicitly overrides `code`
+and `reason`/`message`, and we will normalise the cross-platform wrapper
+prefix on the JS side.
+
+### iOS
+
+Add two `Exception` subclasses, one per error enum, that project the enum's
+`code` and `message` through `expo-modules-core`:
+
+```swift
+final class SpotifyAuthException: Exception, @unchecked Sendable {
+  private let spotifyCode: String
+  private let spotifyMessage: String
+
+  init(_ error: SpotifyError, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.spotifyCode = error.code
+    self.spotifyMessage = error.message
+    super.init(file: file, line: line, function: function)
+    self.cause = error.underlyingCause
+  }
+
+  override var code: String { spotifyCode }
+  override var reason: String { spotifyMessage }
+}
+```
+
+`SpotifyRefreshException` mirrors this for `SpotifyRefreshError`.
+
+The module catches and re-throws with the new types:
+
+```swift
+} catch let error as SpotifyError {
+  …
+  throw SpotifyAuthException(error)
+}
+```
+
+### Preserve the underlying NSError as `cause`
+
+`SpotifyError.underlying` previously stored the original `NSError`
+flattened into a synthetic NSError whose only populated field was
+`NSLocalizedDescriptionKey`. The original `NSUnderlyingErrorKey` chain was
+discarded. The new shape carries the rendered string **and** the original
+error:
+
+```swift
+case underlying(message: String, cause: Error)
+```
+
+`mapSDKError` passes the original NSError through unchanged as `cause`, and
+the rendered string into `message`. `SpotifyAuthException.init` reads
+`SpotifyError.underlyingCause` and sets `Exception.cause` accordingly, so
+the chain survives into JS-side `err.cause` (visible to Sentry breadcrumbs,
+React Native red-box, debug logs).
+
+### Android
+
+No change. `CodedException(code, message, cause)` already does the right
+thing.
+
+### JS — normalise the wrapper prefix
+
+`expo-modules-core` adds a platform-specific wrapper prefix to the message
+of any error thrown from an `AsyncFunction` body:
+
+- iOS: `"Calling the '<fn>' function has failed\n→ Caused by: <reason>"`
+- Android: `"Call to function '<module>.<fn>' has been rejected.\n→ Caused by: <reason>"`
+
+The canonical `→ Caused by:` separator (with a trailing space) is identical
+on both platforms. `rethrowAsSpotifyError` in `src/index.ts` now:
+
+1. Prefers `err.code` (set structurally by `expo-modules-core`'s reject
+   call from `Exception.code`/`CodedException.code`).
+2. Strips the wrapper prefix by splitting on the last `→ Caused by:`
+   occurrence (separator includes a trailing space) and using the suffix
+   as the JS-facing `message`.
+3. Falls back to the pre-0.9 `"CODE: msg"` regex parse only for consumers
+   still running against older native binaries (degrades gracefully rather
+   than breaking).
+
+The result is identical JS surface on both platforms:
+
+```ts
+catch (e) {
+  if (e instanceof SpotifyError) {
+    e.code        // → "USER_CANCELLED", "NETWORK_ERROR", "UNKNOWN", …
+    e.message     // → "Authentication was cancelled by the user"
+                  //   (iOS: original SpotifyError.message, including the
+                  //    full NSError chain for `.underlying`;
+                  //    Android: localizedMessage from the CodedException)
+  }
+}
+```
+
+## Alternatives Considered
+
+| Alternative | Verdict | Reason |
+| --- | --- | --- |
+| Status quo (`GenericException("\(code): \(message)")`) + JS regex parse | **Rejected** | The regex never matched because `GenericException.reason` was `"undefined reason"`, not `"CODE: msg"`. The intended contract was simply not delivered. |
+| `Exception(name: …, description: …, code: …)` initialiser | **Rejected** | The 4-arg initialiser sets `description` and `code` but not `reason`, and `description` is `lazy var` that is later overwritten by `concatDescription(reason, withCause: cause)` in some Expo versions. Subclassing is the only stable contract. |
+| Drop the iOS coordinator's `SpotifyError` enum, throw `Exception` subclasses directly | **Rejected** | The enum is useful internally (e.g. `cancelPending()` resumes the continuation with `SpotifyError.userCancelled`; the `actor`'s state transitions reason about it). Keeping it and bridging via a thin wrapper preserves separation between "coordinator error model" and "JS-bridge error model." |
+| Encode the structured error in the `userInfo`/event payload and have JS reconstruct it | **Rejected** | We already do this for the `onSessionChange` event (`didFail` payload carries `{ code, message }`). Duplicating it as the rejection path adds two failure surfaces (event-listener vs awaited promise) that can disagree on shape. Native rejection should be the source of truth; the event is a convenience mirror. |
+| Match the wrapper prefix exactly between iOS and Android | **Rejected** | The wrapper prefix is owned by `expo-modules-core`, not us. Stripping it in JS is the right seam — and the canonical `→ Caused by:` separator is already cross-platform. |
+
+## Consequences
+
+### Positive
+
+- The public `SpotifyError` contract is now actually delivered on iOS, not
+  just promised by the README.
+- Consumers can branch on `e.code` cleanly (no `e.code === "UNKNOWN"`
+  fallback for cases that were never genuinely unknown).
+- Underlying `NSError` chains survive into JS via `err.cause`, giving
+  Sentry and debuggers the full diagnostic picture (`NSURLErrorDomain
+  -1200` TLS errors, `SPTErrorDomain` codes, etc.).
+- Same JS surface on both platforms; the only platform-detectable
+  difference is the exact phrasing of the wrapper prefix in the *raw*
+  native `err.message`, which we strip before consumers see it.
+- The JS-side regex fallback keeps consumers on older native binaries
+  working during the upgrade window.
+
+### Negative
+
+- Two extra `Exception` subclasses to maintain on iOS (one per error enum).
+  Acceptable — they're each ~10 lines and the pattern is mechanical.
+- `SpotifyError.underlying` is now a two-arg associated value
+  (`message:cause:`). Internal-only enum, so no public-API break, but any
+  in-repo `switch` exhaustiveness errors needed updating.
+
+### Neutral
+
+- The `onSessionChange` `didFail` event still emits
+  `{ code, message }` with the pre-wrap message — unchanged. Consumers
+  using the event listener path were never affected by the bug; they get
+  the same shape as before.
+
+## Implementation
+
+| File | Change |
+| --- | --- |
+| `ios/SpotifyAuthCoordinator.swift` | `SpotifyError.underlying` becomes `(message: String, cause: Error)`; add `underlyingCause` projection; add `SpotifyAuthException: Exception` subclass; `mapSDKError` now stores the original `NSError` as cause. |
+| `ios/SpotifyTokenRefreshClient.swift` | Add `underlyingCause` to `SpotifyRefreshError`; add `SpotifyRefreshException: Exception` subclass. |
+| `ios/ExpoSpotifySDKModule.swift` | Replace `throw GenericException(...)` with `throw SpotifyAuthException(error)` / `throw SpotifyRefreshException(error)`. |
+| `android/.../*.kt` | No change. |
+| `src/index.ts` | Replace the legacy `"CODE: msg"` regex parse with: prefer `err.code` set by `expo-modules-core`, strip the wrapper prefix via the `→ Caused by:` separator, retain the regex as a legacy fallback. |
+| `README.md` | Document that on iOS, `SpotifyError.UNKNOWN.message` now contains the rendered underlying NSError chain (domain, code, descriptions), making the historically-opaque "Spotify auth failed" log line genuinely diagnosable. |
+
+## Validation
+
+Verified by:
+
+1. `yarn typecheck` / `yarn lint` / `yarn build` / `yarn test` all pass
+   after the change.
+2. End-to-end on a real iOS device with a deliberately broken TLS path
+   (e.g. Proxyman intercepting `tokenSwapURL` without a trusted root CA):
+   `authenticateAsync` now rejects with
+   `{ code: "UNKNOWN", message: "NSURLErrorDomain code -1200 \"<desc>\" → underlying: …" }`
+   instead of
+   `{ code: "UNKNOWN", message: "Calling the 'authenticateAsync' function has failed" }`.
+3. `USER_CANCELLED` on iOS still produces the same JS shape it did before
+   (the iOS coordinator already pattern-matched `description.contains("cancel")`
+   into `SpotifyError.userCancelled`; the new bridging just stops eating
+   the code).
+4. Android JS shape unchanged across the upgrade (the regex fallback was
+   never engaged on Android because `err.code` was always set; new code
+   path takes the same branch).

--- a/ios/ExpoSpotifySDKModule.swift
+++ b/ios/ExpoSpotifySDKModule.swift
@@ -43,7 +43,7 @@ public class ExpoSpotifySDKModule: Module {
           "type": "didFail",
           "error": ["code": error.code, "message": error.message],
         ])
-        throw GenericException("\(error.code): \(error.message)")
+        throw SpotifyAuthException(error)
       }
     }
 
@@ -79,13 +79,13 @@ public class ExpoSpotifySDKModule: Module {
           "type": "didFail",
           "error": ["code": error.code, "message": error.message],
         ])
-        throw GenericException("\(error.code): \(error.message)")
+        throw SpotifyAuthException(error)
       } catch let error as SpotifyRefreshError {
         self.sendEvent(EVENT_SESSION_CHANGE, [
           "type": "didFail",
           "error": ["code": error.code, "message": error.message],
         ])
-        throw GenericException("\(error.code): \(error.message)")
+        throw SpotifyRefreshException(error)
       }
     }
   }

--- a/ios/SpotifyAuthCoordinator.swift
+++ b/ios/SpotifyAuthCoordinator.swift
@@ -1,3 +1,4 @@
+import ExpoModulesCore
 import Foundation
 import SpotifyiOS
 
@@ -9,7 +10,7 @@ enum SpotifyError: Error {
   case authInProgress
   case userCancelled
   case spotifyNotInstalled
-  case underlying(Error)
+  case underlying(message: String, cause: Error)
 
   var code: String {
     switch self {
@@ -23,13 +24,45 @@ enum SpotifyError: Error {
 
   var message: String {
     switch self {
-    case .invalidConfiguration(let m): return m
-    case .authInProgress:              return "Another authentication request is already in progress"
-    case .userCancelled:               return "Authentication was cancelled by the user"
-    case .spotifyNotInstalled:         return "The Spotify app is not installed on this device"
-    case .underlying(let err):         return err.localizedDescription
+    case .invalidConfiguration(let m):     return m
+    case .authInProgress:                  return "Another authentication request is already in progress"
+    case .userCancelled:                   return "Authentication was cancelled by the user"
+    case .spotifyNotInstalled:             return "The Spotify app is not installed on this device"
+    case .underlying(let message, _):      return message
     }
   }
+
+  /// The original error that caused this failure, if any. Surfaced as the
+  /// JS-facing exception's `cause` so debugging / Sentry breadcrumbs keep the
+  /// full chain rather than collapsing into "undefined reason".
+  var underlyingCause: Error? {
+    switch self {
+    case .underlying(_, let cause): return cause
+    default:                        return nil
+    }
+  }
+}
+
+/// `Exception` subclass that projects a `SpotifyError`'s `code` and `message`
+/// through `expo-modules-core`'s exception bridge so JS receives the structured
+/// code and a meaningful reason — not the default "undefined reason" placeholder.
+///
+/// Without this wrapper an `AsyncFunction` rejection collapses to
+/// `FunctionCallException` → `cause.reason = "undefined reason"` because the
+/// previously-used `GenericException<String>` does not override `reason`.
+final class SpotifyAuthException: Exception, @unchecked Sendable {
+  private let spotifyCode: String
+  private let spotifyMessage: String
+
+  init(_ error: SpotifyError, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.spotifyCode = error.code
+    self.spotifyMessage = error.message
+    super.init(file: file, line: line, function: function)
+    self.cause = error.underlyingCause
+  }
+
+  override var code: String { spotifyCode }
+  override var reason: String { spotifyMessage }
 }
 
 /// `actor` ensures `pending` is mutated only on the actor's serial executor;
@@ -167,11 +200,10 @@ final class SpotifySessionDelegateBridge: NSObject, SPTSessionManagerDelegate {
     if description.contains("cancel") {
       return SpotifyError.userCancelled
     }
-    return SpotifyError.underlying(NSError(
-      domain: nsError.domain,
-      code: nsError.code,
-      userInfo: [NSLocalizedDescriptionKey: describeError(nsError)]
-    ))
+    // Keep the original NSError as `cause` so the structured underlying-chain
+    // is preserved (Sentry, debug breadcrumbs); the rendered string goes to
+    // `message` so JS callers get a single human-readable line.
+    return SpotifyError.underlying(message: describeError(nsError), cause: nsError)
   }
 
   /// Build a diagnostic string from an NSError that includes the domain,

--- a/ios/SpotifyTokenRefreshClient.swift
+++ b/ios/SpotifyTokenRefreshClient.swift
@@ -1,3 +1,4 @@
+import ExpoModulesCore
 import Foundation
 
 enum SpotifyRefreshError: Error {
@@ -28,6 +29,33 @@ enum SpotifyRefreshError: Error {
       return m
     }
   }
+
+  /// The original error that caused this failure, if any. Surfaced as the
+  /// JS-facing exception's `cause`.
+  var underlyingCause: Error? {
+    switch self {
+    case .network(let err): return err
+    default:                return nil
+    }
+  }
+}
+
+/// `Exception` subclass that projects a `SpotifyRefreshError`'s `code` and
+/// `message` through `expo-modules-core` so JS sees the structured taxonomy
+/// instead of "undefined reason". Mirrors `SpotifyAuthException`.
+final class SpotifyRefreshException: Exception, @unchecked Sendable {
+  private let spotifyCode: String
+  private let spotifyMessage: String
+
+  init(_ error: SpotifyRefreshError, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.spotifyCode = error.code
+    self.spotifyMessage = error.message
+    super.init(file: file, line: line, function: function)
+    self.cause = error.underlyingCause
+  }
+
+  override var code: String { spotifyCode }
+  override var reason: String { spotifyMessage }
 }
 
 struct SpotifyRefreshResult {

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,8 +155,6 @@ function addSessionChangeListener(
   ) as EventSubscription;
 }
 
-const ERROR_PREFIX_RE = /^([A-Z_][A-Z0-9_]*):\s*(.*)$/s;
-
 const VALID_CODES: ReadonlySet<SpotifyErrorCode> = new Set<SpotifyErrorCode>([
   "USER_CANCELLED",
   "AUTH_IN_PROGRESS",
@@ -169,18 +167,38 @@ const VALID_CODES: ReadonlySet<SpotifyErrorCode> = new Set<SpotifyErrorCode>([
   "UNKNOWN",
 ]);
 
+// expo-modules-core wraps both iOS `Exception`s and Android `CodedException`s
+// in a function-call-level decorator that prepends a platform-specific
+// prefix (e.g. "Calling the 'authenticateAsync' function has failed" on iOS,
+// "Call to function 'ExpoSpotifySDK.authenticateAsync' has been rejected." on
+// Android) and joins the original reason with the canonical "→ Caused by: "
+// separator. Strip the wrapper so JS consumers see only the native module's
+// own reason — `code` is preserved structurally either way.
+const CAUSE_SEPARATOR = "→ Caused by: ";
+
+// Legacy fallback for native modules that don't propagate `code` — pre-0.9
+// iOS shipped `GenericException("<CODE>: <msg>")`, surfacing as a literal
+// "CODE: message" prefix in `err.message` with no structured code.
+const LEGACY_CODE_PREFIX_RE = /^([A-Z_][A-Z0-9_]*):\s*(.*)$/s;
+
+function unwrapReason(message: string): string {
+  const idx = message.lastIndexOf(CAUSE_SEPARATOR);
+  return idx === -1 ? message : message.slice(idx + CAUSE_SEPARATOR.length);
+}
+
 function rethrowAsSpotifyError(err: unknown): never {
   if (err instanceof SpotifyError) throw err;
   if (err instanceof Error) {
-    const m = err.message.match(ERROR_PREFIX_RE);
+    const reason = unwrapReason(err.message);
+    const maybeCode = (err as Error & { code?: string }).code;
+    if (maybeCode && VALID_CODES.has(maybeCode as SpotifyErrorCode)) {
+      throw new SpotifyError(maybeCode as SpotifyErrorCode, reason);
+    }
+    const m = reason.match(LEGACY_CODE_PREFIX_RE);
     if (m && VALID_CODES.has(m[1] as SpotifyErrorCode)) {
       throw new SpotifyError(m[1] as SpotifyErrorCode, m[2]);
     }
-    const maybeCode = (err as Error & { code?: string }).code;
-    if (maybeCode && VALID_CODES.has(maybeCode as SpotifyErrorCode)) {
-      throw new SpotifyError(maybeCode as SpotifyErrorCode, err.message);
-    }
-    throw new SpotifyError("UNKNOWN", err.message);
+    throw new SpotifyError("UNKNOWN", reason);
   }
   throw new SpotifyError("UNKNOWN", String(err));
 }


### PR DESCRIPTION
The iOS module re-threw caught `SpotifyError` / `SpotifyRefreshError` via `GenericException<String>`, whose `param` carried `"<CODE>: <message>"` but which never overrode `Exception.reason` — leaving it as the literal default `"undefined reason"`. `expo-modules-core` then wrapped that in `FunctionCallException`, so every iOS failure that wasn't `USER_CANCELLED` arrived in JS as:

  { code: "UNKNOWN",
    message: "Calling the 'authenticateAsync' function has failed" }

…with `\n→ Caused by: undefined reason` tacked on. The structured Spotify code and the underlying NSError chain (TLS errors, SPTErrorDomain codes, URLSession failures) were dropped between Swift and JS — visible only via NSLog in the Xcode console.

Fix:

- Add `SpotifyAuthException` / `SpotifyRefreshException` as proper `Exception` subclasses that override `code` and `reason` from their source enum, and chain the underlying error via `Exception.cause`.
- Extend `SpotifyError.underlying` to carry `(message: String, cause: Error)` so the original `NSError` (with its full `NSUnderlyingErrorKey` chain) survives instead of being flattened into a synthetic NSError.
- Replace both `throw GenericException(...)` sites with the new wrappers.
- Simplify `rethrowAsSpotifyError` in `src/index.ts`: prefer `err.code` (now reliably propagated by both platforms), and strip the platform-specific function-call wrapper by splitting on the canonical `→ Caused by:` separator. Retain the legacy `"CODE: msg"` regex as a fallback for consumers running against older native binaries.

Android already routed `CodedException(code, message, cause)` through `DecoratedException` correctly, so no Kotlin changes are needed — the JS shape is now identical across platforms.

See `docs/adr/0003-structured-exception-bridging.md` for the full rationale, alternatives considered, and validation steps.