### PR TITLE
docs: add CONTEXT.md, V1_PLAN.md and ADRs 0004–0006

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,46 @@
+# Project context — @wwdrew/expo-spotify-sdk
+
+Reference for humans and agents. Use this file to keep terminology straight when talking about the various Spotify SDKs, their relationship to the Spotify Web API, and what this library does (and explicitly does not) wrap.
+
+## Commits
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description` (e.g. `fix(ios): …`, `feat(android): …`, `docs: …`). Use an optional scope when the change is platform- or area-specific.
+
+## Terminology
+
+| Term | Meaning | **Not** this |
+| --- | --- | --- |
+| **Spotify app** | The official Spotify consumer app installed on the user's device. Performs the actual audio playback for App Remote integrations. | Your app / the host app embedding this library. |
+| **Auth SDK** | The OAuth half of the native Spotify SDKs (`SPTSessionManager` on iOS, `com.spotify.android:auth` on Android). Authenticates the user via the installed Spotify app or web fallback and returns an OAuth access token. | A user-data API. It only signs the user in. |
+| **App Remote SDK** | The playback-control half of the native Spotify SDKs (`SpotifyAppRemote` on iOS, `com.spotify.android:app-remote` on Android). Connects to the running Spotify app over IPC and remote-controls it: transport, queue, now-playing state, user library state, content browsing, cover art. **Requires Spotify Premium.** | An audio engine. The host app never plays audio itself; the Spotify app does. |
+| **Web API** | Spotify's REST API at `https://api.spotify.com/v1`. Catalog, library, recently played, top items, audio features, recommendations, playlist mutations, Connect device transfer. | Part of this library. Consumers call it themselves with the access token from `authenticateAsync`. |
+| **Web Playback SDK** | Spotify's browser-only JS SDK that plays audio in the page. | Part of this library. Out of scope (no web platform). |
+| **Spotify Connect** | Spotify's protocol for transferring playback between devices (phone, speaker, desktop). Exposed via the Web API (`/me/player/*`), not App Remote. | Wrapped by this library. |
+| **Premium** | A paid Spotify subscription. Required by the App Remote SDK to play / control playback. The Auth SDK does not require Premium. | A library concept. We surface Premium-gated failures from the SDK; we don't enforce it ourselves. |
+| **Access token** | OAuth bearer token returned by `authenticateAsync`. Consumers pass it to `AppRemote.connect()` and use it to call the Web API themselves. | Persisted by this library. Consumers store and refresh it; the library holds no token state. |
+| **Connection** | The live IPC channel between the host app and the Spotify app, established via `AppRemote.connect(accessToken)`. Required before any `Player` / `User` / `Content` / `Images` call. Can drop spontaneously (token expired, Spotify app killed). | A persistent socket. Re-connecting after a drop requires a fresh `connect()` call with a current access token. |
+| **Connection state** | One of `disconnected` / `connecting` / `connected`. Pushed via `AppRemote.addConnectionStateListener`. | The auth session state — those are independent (you can be authenticated but disconnected). |
+| **Spotify URI** | The Spotify URI scheme — `spotify:track:<id>`, `spotify:album:<id>`, `spotify:playlist:<id>`, `spotify:artist:<id>`, `spotify:show:<id>`, `spotify:episode:<id>`. The universal identifier accepted by `Player.play()`, `User.getLibraryState()`, `User.addToLibrary()`, etc. Surfaced in TypeScript as a branded `SpotifyURI` type — consumers construct via `SpotifyURI.from(str)` (validating) or `SpotifyURI.unsafe(str)` (skipping validation). | An HTTPS URL. Spotify also has `https://open.spotify.com/track/<id>` open-graph URLs; App Remote takes the `spotify:` form. |
+| **SpotifyError** | Abstract base class shared by every error thrown by this library. Carries `code` and `namespace` properties. Catch via `instanceof SpotifyError` for "any failure from this library" handling. | A concrete class. Always thrown as one of the per-namespace subclasses (`AuthError`, `AppRemoteError`, `PlayerError`, `UserError`, `ContentError`, `ImagesError`). |
+| **Player state** | A snapshot of the Spotify app's current playback: current track + metadata, playback position, paused/playing, shuffle mode, repeat mode, playback restrictions (can skip next? can skip prev? can repeat? can shuffle?), crossfade state, podcast playback speed. Pushed via `Player.addPlayerStateListener`. | The connection state, or the user's capabilities. |
+| **Capabilities** | Spotify-side feature flags for the signed-in user. Chiefly `canPlayOnDemand` — `false` for Free-tier users, meaning explicit `Player.play(uri)` calls will fail and only shuffle-play-from-context is allowed. Pushed via `User.addCapabilitiesListener`. | A Premium check. Premium is the underlying cause but `canPlayOnDemand` is what App Remote actually reports. |
+| **Library state** | For a given URI, whether it is in the user's saved library (`isAdded`) and whether it can be added (`canAdd`). Pushed via `User.addLibraryStateListener(uri)`. | The user's full saved library. App Remote only reports state for one URI at a time. |
+| **Content item** | The browseable unit returned by `Content.getRecommendedContentItems()` — represents a section, playlist, album, or track in Spotify's curated browse tree. Children navigated via `Content.getChildren(item)`. Each item carries an image-representable handle usable with `Images.load()`. | A full catalog object. Content items are a navigation surface, not the Web-API catalog. |
+
+**Rule of thumb:** This library wraps the **Auth SDK** and (in v1) the **App Remote SDK**. Anything that lives at `api.spotify.com` is the consumer's responsibility — they have the access token, they call REST.
+
+## v1.0.0 direction
+
+`v1.0.0` adds App Remote support (transport, now-playing, hooks) on top of the existing Auth surface, drops support for iOS deployment targets older than what Expo SDK 56 requires, and is the cutoff for the last `v0.x` release that supports SDK 55 and earlier.
+
+**Explicitly not in v1:**
+
+- Spotify Web API wrappers (catalog, library reads, recently played, top items, recommendations, playlist mutations) — consumers call REST themselves with the access token. Spotify is tightening Web API access (see [Feb 2026 migration](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide)) and we don't want to be on the hook for that surface.
+- Spotify Connect device transfer / device list — Web API only.
+- Web platform / Web Playback SDK — native SDKs only.
+- Any in-app audio playback — Spotify's model is "remote-control the Spotify app". No exceptions.
+
+## Related docs
+
+- [README.md](./README.md) — install and current (`v0.x`) Auth-only API.
+- [docs/adr/](./docs/adr/) — architecture decision records.

--- a/docs/V1_PLAN.md
+++ b/docs/V1_PLAN.md
@@ -1,0 +1,518 @@
+# v1/v2 plan — App Remote + namespaced API
+
+Plan for getting `@wwdrew/expo-spotify-sdk` from its current auth-only `0.8.x` state to a feature-complete native-SDK wrapper covering both halves of Spotify's mobile SDKs: the **Auth SDK** (today) and the **App Remote SDK** (new).
+
+**Status:** Living document — update as features land. Source of truth for per-method status: the [Coverage matrix](#5-coverage-matrix).
+
+**Related:** [CONTEXT.md](../CONTEXT.md) (terminology), [ADR-0004](./adr/0004-no-web-api-wrapper.md), [ADR-0005](./adr/0005-sdk-lane-versioning.md), [ADR-0006](./adr/0006-namespaced-api-and-app-remote-scope.md).
+
+---
+
+## 1. Vision
+
+| Pillar | v1 / v2 target |
+| --- | --- |
+| **Scope** | The **entire native-SDK surface** of Spotify's iOS and Android SDKs — Auth + every documented App Remote API. |
+| **Not scope** | Spotify Web API (`api.spotify.com`), Spotify Connect device transfer, Web Playback SDK. See [ADR-0004](./adr/0004-no-web-api-wrapper.md). |
+| **Platforms** | iOS, Android. No web. |
+| **Public API** | Six namespaces mirroring the SDK split: `Auth`, `AppRemote`, `Player`, `User`, `Content`, `Images` + React hooks. |
+| **Errors** | Per-namespace `SpotifyError` subclasses (`AuthError`, `AppRemoteError`, `PlayerError`, `UserError`, `ContentError`, `ImagesError`) — never silent failure. |
+| **SDK lane** | `v1.x.x` ships on Expo SDK 55 (iOS 15.1+). `v2.x.x` ships on Expo SDK 56+ (iOS 16.4+). Both lanes ship the full feature set. See [ADR-0005](./adr/0005-sdk-lane-versioning.md). |
+
+**North star:** A consumer can integrate Spotify auth + playback control in an Expo / React Native app without writing any native code or learning the underlying SDK's classes.
+
+**Not a goal:** Wrapping `api.spotify.com`. Consumers hold the access token from `Auth.authenticate` and call REST themselves.
+
+---
+
+## 2. What exists today (baseline)
+
+**Current release:** `0.8.0` (Expo SDK 55).
+
+| Domain | Public API | iOS | Android | Web |
+| --- | --- | --- | --- | --- |
+| Auth | `isAvailable`, `authenticateAsync`, `cancelPendingAuthAsync`, `refreshSessionAsync`, `addSessionChangeListener` | ✅ | ✅ | — (no-op) |
+| App Remote | — | ❌ | ❌ | — |
+
+**Public API shape:** Flat top-level functions exported from `src/index.ts`. Single `SpotifyError` class with `SpotifyErrorCode` union of 9 codes.
+
+---
+
+## 3. Target architecture
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  TypeScript public API (6 namespaces + hooks)                │
+│  Auth · AppRemote · Player · User · Content · Images         │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+┌───────────────────────────▼─────────────────────────────────┐
+│  expo-module bridge (AsyncFunction per method, Events per    │
+│  subscription stream)                                        │
+└─────────────┬───────────────────────────────┬─────────────────┘
+              │                               │
+   ┌──────────▼──────────┐         ┌──────────▼──────────┐
+   │  iOS                 │         │  Android             │
+   │  Auth: SPTSessionMgr │         │  Auth: AuthSDK 4.0.1 │
+   │  Remote: SpotifyApp- │         │  Remote: spotify-    │
+   │          Remote 5.x  │         │          android-    │
+   │                      │         │          app-remote  │
+   └─────────────────────┘         └─────────────────────┘
+              │                               │
+              └───────────┬───────────────────┘
+                          ▼
+              (No HTTP. No api.spotify.com.)
+```
+
+### Layers
+
+| Layer | Responsibility |
+| --- | --- |
+| `src/auth/` | `Auth` namespace + types + `AuthError` |
+| `src/app-remote/` | `AppRemote` namespace + `ConnectionState` types + `AppRemoteError` |
+| `src/player/` | `Player` namespace + `PlayerState` types + `PlayerError` |
+| `src/user/` | `User` namespace + `Capabilities` / `LibraryState` types + `UserError` |
+| `src/content/` | `Content` namespace + `ContentItem` types + `ContentError` |
+| `src/images/` | `Images` namespace + `ImagesError` |
+| `src/hooks/` | React hooks (`useSession`, `useConnectionState`, `usePlayerState`, derived helpers) built on `useSyncExternalStore` |
+| `src/uri/` | `SpotifyURI` branded type + helpers |
+| `src/error.ts` | Abstract `SpotifyError` base class |
+| Native (iOS) | Swift modules per namespace; `SpotifyAppRemoteCoordinator` actor mirroring `SpotifyAuthCoordinator` |
+| Native (Android) | Kotlin modules per namespace |
+
+---
+
+## 4. Public API surface
+
+### Namespaces
+
+```ts
+import {
+  Auth, AppRemote, Player, User, Content, Images,
+  SpotifyURI,
+  SpotifyError, AuthError, AppRemoteError, PlayerError,
+  UserError, ContentError, ImagesError,
+} from "@wwdrew/expo-spotify-sdk";
+
+import {
+  useSession, useConnectionState, usePlayerState,
+  useCurrentTrack, useIsPlaying, usePlaybackPosition,
+  useCapabilities, useLibraryState,
+} from "@wwdrew/expo-spotify-sdk";
+```
+
+### Full method list
+
+**`Auth`** (replaces all v0.x top-level functions)
+
+| Method | Returns |
+| --- | --- |
+| `Auth.isAvailable()` | `boolean` |
+| `Auth.authenticate(config: AuthenticateConfig)` | `Promise<SpotifySession>` |
+| `Auth.refresh(config: RefreshConfig)` | `Promise<SpotifySession>` |
+| `Auth.cancelPending()` | `Promise<void>` |
+| `Auth.addListener("sessionChange", cb)` | `Subscription` |
+
+**`AppRemote`** (connection lifecycle)
+
+| Method | Returns |
+| --- | --- |
+| `AppRemote.connect(accessToken, options?)` | `Promise<void>` |
+| `AppRemote.disconnect()` | `Promise<void>` |
+| `AppRemote.isConnected()` | `boolean` |
+| `AppRemote.getConnectionState()` | `ConnectionState` |
+| `AppRemote.addListener("connectionStateChange", cb)` | `Subscription` |
+| `AppRemote.addListener("connectionError", cb)` | `Subscription` |
+
+**`Player`** (transport + queue + state)
+
+| Method | Returns |
+| --- | --- |
+| `Player.play(uri: SpotifyURI)` | `Promise<void>` |
+| `Player.pause()` | `Promise<void>` |
+| `Player.resume()` | `Promise<void>` |
+| `Player.skipNext()` | `Promise<void>` |
+| `Player.skipPrevious()` | `Promise<void>` |
+| `Player.seekTo(positionMs: number)` | `Promise<void>` |
+| `Player.setShuffle(enabled: boolean)` | `Promise<void>` |
+| `Player.setRepeatMode(mode: RepeatMode)` | `Promise<void>` |
+| `Player.setPodcastPlaybackSpeed(speed: PodcastPlaybackSpeed)` | `Promise<void>` |
+| `Player.queue(uri: SpotifyURI)` | `Promise<void>` |
+| `Player.getPlayerState()` | `Promise<PlayerState>` |
+| `Player.getCrossfadeState()` | `Promise<CrossfadeState>` |
+| `Player.addListener("playerStateChange", cb)` | `Subscription` |
+
+**`User`** (capabilities + per-URI library state + saves)
+
+| Method | Returns |
+| --- | --- |
+| `User.getCapabilities()` | `Promise<Capabilities>` |
+| `User.getLibraryState(uri: SpotifyURI)` | `Promise<LibraryState>` |
+| `User.addToLibrary(uri: SpotifyURI)` | `Promise<void>` |
+| `User.removeFromLibrary(uri: SpotifyURI)` | `Promise<void>` |
+| `User.addListener("capabilitiesChange", cb)` | `Subscription` |
+| `User.addLibraryStateListener(uri: SpotifyURI, cb)` | `Subscription` |
+
+**`Content`** (Spotify-curated browse tree)
+
+| Method | Returns |
+| --- | --- |
+| `Content.getRecommendedContentItems(type: ContentType)` | `Promise<ContentItem[]>` |
+| `Content.getChildren(item: ContentItem)` | `Promise<ContentItem[]>` |
+
+**`Images`** (cover art)
+
+| Method | Returns |
+| --- | --- |
+| `Images.load(item: ImageRepresentable, size)` | `Promise<{ uri: string }>` (file URI) |
+
+### Hooks
+
+| Hook | Returns | Source |
+| --- | --- | --- |
+| `useSession()` | `SpotifySession \| null` | `Auth.addListener("sessionChange", ...)` |
+| `useConnectionState()` | `ConnectionState` | `AppRemote.addListener("connectionStateChange", ...)` |
+| `usePlayerState()` | `PlayerState \| null` | `Player.addListener("playerStateChange", ...)` |
+| `useCurrentTrack()` | `Track \| null` | derived from `usePlayerState` |
+| `useIsPlaying()` | `boolean` | derived from `usePlayerState` |
+| `usePlaybackPosition()` | `number` (ms, ticks ~250ms while playing) | derived from `usePlayerState` |
+| `useCapabilities()` | `Capabilities \| null` | `User.addListener("capabilitiesChange", ...)` |
+| `useLibraryState(uri: SpotifyURI)` | `LibraryState \| null` | `User.addLibraryStateListener(uri, ...)` |
+
+All hooks built on `useSyncExternalStore` for correct tearing-free behaviour.
+
+### `SpotifyURI`
+
+```ts
+type SpotifyURI = string & { readonly __brand: 'SpotifyURI' };
+type SpotifyResourceType = 'track' | 'album' | 'playlist' | 'artist' | 'show' | 'episode';
+
+const SpotifyURI = {
+  from(uri: string): SpotifyURI,       // validates, throws on invalid
+  unsafe(uri: string): SpotifyURI,     // skip validation
+  parse(uri: SpotifyURI): { type: SpotifyResourceType; id: string },
+  build(type: SpotifyResourceType, id: string): SpotifyURI,
+  isValid(uri: string): uri is SpotifyURI,
+};
+```
+
+---
+
+## 5. Coverage matrix
+
+Legend: ✅ shipped · 🟡 in progress · ⬜ not started · ➖ N/A on this platform
+
+### 5.1 Auth (already shipped pre-v1)
+
+| Method | iOS | Android |
+| --- | --- | --- |
+| `Auth.isAvailable()` | ⬜ (rename of `isAvailable`) | ⬜ |
+| `Auth.authenticate()` | ⬜ (rename of `authenticateAsync`) | ⬜ |
+| `Auth.refresh()` | ⬜ | ⬜ |
+| `Auth.cancelPending()` | ⬜ | ➖ (no-op) |
+| `Auth.addListener("sessionChange", ...)` | ⬜ | ⬜ |
+
+### 5.2 AppRemote
+
+| Method | iOS | Android |
+| --- | --- | --- |
+| `AppRemote.connect()` | ⬜ | ⬜ |
+| `AppRemote.disconnect()` | ⬜ | ⬜ |
+| `AppRemote.isConnected()` | ⬜ | ⬜ |
+| `AppRemote.getConnectionState()` | ⬜ | ⬜ |
+| `addListener("connectionStateChange", ...)` | ⬜ | ⬜ |
+| `addListener("connectionError", ...)` | ⬜ | ⬜ |
+
+### 5.3 Player
+
+| Method | iOS | Android |
+| --- | --- | --- |
+| `Player.play()` | ⬜ | ⬜ |
+| `Player.pause()` / `resume()` | ⬜ | ⬜ |
+| `Player.skipNext()` / `skipPrevious()` | ⬜ | ⬜ |
+| `Player.seekTo()` | ⬜ | ⬜ |
+| `Player.setShuffle()` / `setRepeatMode()` | ⬜ | ⬜ |
+| `Player.setPodcastPlaybackSpeed()` | ⬜ | ⬜ |
+| `Player.queue()` | ⬜ | ⬜ |
+| `Player.getPlayerState()` | ⬜ | ⬜ |
+| `Player.getCrossfadeState()` | ⬜ | ⬜ |
+| `addListener("playerStateChange", ...)` | ⬜ | ⬜ |
+
+### 5.4 User
+
+| Method | iOS | Android |
+| --- | --- | --- |
+| `User.getCapabilities()` | ⬜ | ⬜ |
+| `User.getLibraryState()` | ⬜ | ⬜ |
+| `User.addToLibrary()` / `removeFromLibrary()` | ⬜ | ⬜ |
+| `addListener("capabilitiesChange", ...)` | ⬜ | ⬜ |
+| `addLibraryStateListener(uri, ...)` | ⬜ | ⬜ |
+
+### 5.5 Content
+
+| Method | iOS | Android |
+| --- | --- | --- |
+| `Content.getRecommendedContentItems()` | ⬜ | ⬜ |
+| `Content.getChildren()` | ⬜ | ⬜ |
+
+### 5.6 Images
+
+| Method | iOS | Android |
+| --- | --- | --- |
+| `Images.load()` | ⬜ | ⬜ |
+
+### 5.7 Hooks (TypeScript-only; no native work)
+
+| Hook | Status |
+| --- | --- |
+| All hooks listed in §4 | ⬜ |
+
+---
+
+## 6. Implementation phases
+
+Ordered for vertical slices (each phase produces something demoable on device) and dependency order (foundation → connection → player → polish → branch cut → SDK 56 migration).
+
+**Development sequence:** All App Remote work (Phases 1–6) happens on `main` while `main` is still on Expo SDK 55 — the same toolchain `0.8.x` ships on today. Only after v1.0.0 is feature-complete and tagged on `main` do we cut the `v1` branch (as the long-lived SDK 55 lane) and then migrate `main` itself to SDK 56 in Phase 7 to become the v2.0.0 line. This avoids doing the App Remote work twice (once per SDK lane); the SDK 56 migration is then a focused, isolated change on top of a known-good v1.0.0.
+
+### Phase 0 — Repo & doc setup (no branch cuts, no SDK bumps yet)
+
+| Task | Deliverable |
+| --- | --- |
+| `CONTEXT.md` | ✅ (this PR) |
+| ADRs 0004/0005/0006 | ✅ (this PR) |
+| `V1_PLAN.md` | ✅ (this PR) |
+| CI on `main` extended to cover the new namespace structure | GitHub Actions matrix still on SDK 55 |
+
+**Exit:** Docs published on `main`. No branch or SDK changes — `main` continues to ship `0.8.x`-compatible builds while Phases 1–6 progress on it.
+
+### Phase 1 — Foundation: error classes, URI type, namespace skeleton
+
+| Task | Deliverable |
+| --- | --- |
+| `src/error.ts` | Abstract `SpotifyError` base class |
+| Per-namespace error classes | `AuthError`, `AppRemoteError`, `PlayerError`, `UserError`, `ContentError`, `ImagesError` |
+| `src/uri/` | Branded `SpotifyURI` type + helpers |
+| Empty namespace stubs | `Auth`, `AppRemote`, `Player`, `User`, `Content`, `Images` exported from `src/index.ts` |
+| iOS exception subclasses per namespace | Following the ADR-0003 pattern for each new error class |
+| Android `CodedException` subclasses per namespace | Same |
+| Migration of existing auth functions | `authenticateAsync` → `Auth.authenticate`, etc. — TS shim only at first; bridge unchanged |
+
+**Exit:** `Auth.authenticate(...)` works identically to `authenticateAsync(...)` on both platforms; all existing 0.8.x tests pass after rename.
+
+### Phase 2 — App Remote: connection lifecycle
+
+| Task | Deliverable |
+| --- | --- |
+| iOS `SpotifyAppRemoteCoordinator` actor | Mirrors `SpotifyAuthCoordinator`; holds `SPTAppRemote` singleton; manages connection state |
+| Android `SpotifyAppRemoteCoordinator` | Same model in Kotlin |
+| `AppRemote.connect` / `disconnect` / `isConnected` / `getConnectionState` | All four methods + connection state subscription |
+| `AppRemote.addListener("connectionStateChange", ...)` | Native → JS event stream |
+| `AppRemote.addListener("connectionError", ...)` | Native → JS event stream |
+| `useConnectionState` hook | Built on `useSyncExternalStore` |
+| `requireConnected(callsite)` internal helper | Throws `AppRemoteError("NOT_CONNECTED", ...)` with call-site name |
+
+**Exit:** Example app can connect / disconnect to a running Spotify app on both platforms; connection state changes propagate to a hook-driven UI banner.
+
+### Phase 3 — Player: transport + state
+
+| Task | Deliverable |
+| --- | --- |
+| All `Player.*` transport methods | `play`, `pause`, `resume`, `skipNext`, `skipPrevious`, `seekTo`, `setShuffle`, `setRepeatMode`, `setPodcastPlaybackSpeed`, `queue` |
+| `Player.getPlayerState()` / `getCrossfadeState()` | One-shot pull |
+| `Player.addListener("playerStateChange", ...)` | Native → JS event stream |
+| `usePlayerState` hook + `useCurrentTrack`, `useIsPlaying`, `usePlaybackPosition` derived hooks | Built on `useSyncExternalStore` |
+| `PREMIUM_REQUIRED` normalization | iOS and Android error mappers detect Spotify's "can't play on demand" rejection and surface as `PlayerError("PREMIUM_REQUIRED", ...)` |
+
+**Exit:** Example app's "Now Playing" screen reflects the running Spotify app's state in real time; transport buttons work for Premium users; non-Premium users get a `PREMIUM_REQUIRED` error from `Player.play`.
+
+### Phase 4 — User: capabilities + library state
+
+| Task | Deliverable |
+| --- | --- |
+| `User.getCapabilities()` + subscription | + `useCapabilities` hook |
+| `User.getLibraryState(uri)` + per-URI subscription | + `useLibraryState(uri)` hook |
+| `User.addToLibrary` / `removeFromLibrary` | Library state push fires automatically |
+
+**Exit:** Example app shows a "save" button on the now-playing screen wired to `useLibraryState`; gated by `useCapabilities().canPlayOnDemand`.
+
+### Phase 5 — Content + Images
+
+| Task | Deliverable |
+| --- | --- |
+| `Content.getRecommendedContentItems()` / `getChildren()` | Recursive content browsing |
+| `Images.load()` | Bitmap fetch → temp file → return `{ uri }` |
+| `ImageRepresentable` typing | Union of `Track`, `Album`, `Artist`, `ContentItem` |
+
+**Exit:** Example app has a "Browse" screen that walks the recommended content tree with cover art images.
+
+### Phase 6 — v1.0.0 hardening (still on `main`, still on SDK 55)
+
+| Task | Deliverable |
+| --- | --- |
+| Error normalization audit | Every native code path that can fail returns the right `*Error` subclass and code |
+| README rewrite | New API surface, migration table from v0.x, curried-wrapper recipe for auto-connect, Premium / capabilities doc, error code reference, lane → version mapping (v1.x → SDK 55, v2.x → SDK 56+) |
+| Documentation of every error code | Per `*ErrorCode` enum entry, what causes it, what to do |
+| Example app polish | Loading states, error UI for every error code, accessibility |
+| Cross-platform parity audit | All methods behave the same on iOS and Android (modulo documented platform differences) |
+| Manual QA on real devices, Premium and Free accounts | Sign-off checklist |
+| Tag `v1.0.0` on `main` | Release on the SDK 55 toolchain |
+| Cut `v1` branch from the `v1.0.0` tag | Long-lived SDK 55 maintenance branch starts here. Configure `release-please` to release `v1.x.y` from this branch. |
+
+**Exit:** `v1.0.0` is shipped on npm, the `v1` branch exists and is set up for `v1.x.y` releases. `main` is now free to migrate to SDK 56 in Phase 7.
+
+### Phase 7 — Migrate `main` to Expo SDK 56 (v2.0.0)
+
+| Task | Deliverable |
+| --- | --- |
+| Bump `ios/ExpoSpotifySDK.podspec` deployment target → `:ios, '16.4'` | Required by `expo-modules-core@^4` |
+| Bump `package.json` dev deps to SDK 56 lane (`@expo/config-plugins@^56`, `expo-module-scripts@^56`, `expo-modules-core@^4`) | |
+| Bump `example/` Expo SDK to 56 | New dev build / prebuild; verify on both platforms |
+| Bump Android `compileSdkVersion` / `targetSdkVersion` if Expo SDK 56 requires (currently 35; verify against SDK 56) | |
+| Adopt SDK 56–only API surface where it pays off | Optional: new JSI layer for iOS Swift modules, Kotlin compiler plugin attributes. Not required for parity — only where they materially improve perf or DX. |
+| Update README on `main` to say "v2.x for SDK 56+; see v1.x for SDK 55" | Lane → version mapping |
+| Bump `package.json` version → `2.0.0` | |
+| Run full QA pass on SDK 56 toolchain | Same checklist as Phase 6, this time on SDK 56 |
+| Tag `v2.0.0` on `main` | Release on the SDK 56 toolchain |
+
+**Exit:** `v2.0.0` is shipped on npm. Both lanes are now live: `v1.x` (on `v1` branch, SDK 55) and `v2.x` (on `main`, SDK 56+). Future feature work happens on `main` first; backporting to `v1` is at the maintainer's discretion per [ADR-0005](./adr/0005-sdk-lane-versioning.md).
+
+---
+
+## 7. Error code reference
+
+### `AuthErrorCode`
+
+`USER_CANCELLED` · `AUTH_IN_PROGRESS` · `INVALID_CONFIG` · `NETWORK_ERROR` · `TOKEN_SWAP_FAILED` · `TOKEN_SWAP_PARSE_ERROR` · `SPOTIFY_NOT_INSTALLED` · `AUTH_ERROR` · `UNKNOWN`
+
+(Carried forward unchanged from v0.x `SpotifyErrorCode`.)
+
+### `AppRemoteErrorCode`
+
+| Code | When |
+| --- | --- |
+| `CONNECTION_FAILED` | `connect()` failed (Spotify app missing, refused, IPC handshake failed). |
+| `CONNECTION_LOST` | Established connection dropped (token expired, Spotify app killed). |
+| `NOT_CONNECTED` | Method called requiring a connection (caught here when from `AppRemote.*` itself, mirrored into other namespaces' codes). |
+| `UNKNOWN` | Anything else. |
+
+### `PlayerErrorCode`
+
+| Code | When |
+| --- | --- |
+| `NOT_CONNECTED` | Any `Player.*` call before `AppRemote.connect()` resolved. |
+| `CONNECTION_LOST` | Connection dropped mid-call. |
+| `PREMIUM_REQUIRED` | Spotify rejected because `canPlayOnDemand === false`. |
+| `INVALID_URI` | `SpotifyURI` failed validation at the native boundary. |
+| `INVALID_PARAMETER` | Out-of-range arg (negative seek, bad enum value). |
+| `OPERATION_NOT_ALLOWED` | Player restriction blocks the call (e.g. `skipNext` when restriction says no). |
+| `UNKNOWN` | Anything else. |
+
+### `UserErrorCode`
+
+| Code | When |
+| --- | --- |
+| `NOT_CONNECTED` | Any `User.*` call before `AppRemote.connect()` resolved. |
+| `CONNECTION_LOST` | Connection dropped mid-call. |
+| `INVALID_URI` | Bad URI argument. |
+| `OPERATION_NOT_ALLOWED` | Library mutation blocked (e.g. Free user, region restriction). |
+| `UNKNOWN` | Anything else. |
+
+### `ContentErrorCode`
+
+| Code | When |
+| --- | --- |
+| `NOT_CONNECTED` | Any `Content.*` call before `AppRemote.connect()` resolved. |
+| `CONNECTION_LOST` | Connection dropped mid-call. |
+| `CONTENT_API_UNAVAILABLE` | Older Spotify app version doesn't support the Content API call. |
+| `UNKNOWN` | Anything else. |
+
+### `ImagesErrorCode`
+
+| Code | When |
+| --- | --- |
+| `NOT_CONNECTED` | `Images.load()` before connect. |
+| `INVALID_URI` | The `ImageRepresentable` doesn't have a loadable image. |
+| `IMAGE_LOAD_FAILED` | Spotify rejected the image request, or temp-file write failed. |
+| `UNKNOWN` | Anything else. |
+
+---
+
+## 8. Migration from v0.x
+
+The breaking change is a mechanical rename. v0.x consumers should be able to migrate with grep+sed.
+
+| v0.x (top-level) | v1/v2 (namespaced) |
+| --- | --- |
+| `isAvailable()` | `Auth.isAvailable()` |
+| `authenticateAsync(config)` | `Auth.authenticate(config)` |
+| `refreshSessionAsync(config)` | `Auth.refresh(config)` |
+| `cancelPendingAuthAsync()` | `Auth.cancelPending()` |
+| `addSessionChangeListener(cb)` | `Auth.addListener("sessionChange", cb)` |
+| `SpotifyError` | `SpotifyError` (abstract) **or** `AuthError` (concrete for auth-thrown ones) |
+| `SpotifyErrorCode` | `AuthErrorCode` |
+
+The `SpotifySession` shape, `SpotifyScope`, `SpotifyConfig`, `SpotifyRefreshConfig`, `SpotifySessionChangeEvent` types are unchanged.
+
+**Important type-narrowing change:** v0.x callers doing `if (e instanceof SpotifyError && e.code === 'USER_CANCELLED')` need to switch to `if (e instanceof AuthError && e.code === 'USER_CANCELLED')` — `SpotifyError` is now an abstract base. `instanceof SpotifyError` still works as a catch-all but doesn't narrow `code` to a known union.
+
+---
+
+## 9. v1.0.0 / v2.0.0 release criteria
+
+All required before tagging either major:
+
+- [ ] Phase 0–6 complete on the relevant branch.
+- [ ] Coverage matrix: every method `✅` on iOS and Android.
+- [ ] Example app demonstrates Auth, AppRemote connect/disconnect, Player transport, now-playing state via hooks, User save button gated by capabilities, Content browse with images.
+- [ ] README rewritten with new API + migration table + curried-wrapper recipe.
+- [ ] Every error code has documented "when" and "what to do" in the README.
+- [ ] [ATTRIBUTION.md or equivalent] reflects no Web API wrapping intent.
+- [ ] Manual QA on real devices, Premium and Free accounts.
+
+**Semver after v1 / v2:**
+
+- **`1.x` / `2.x`** — additive methods, new error codes, new hooks. No removal of public exports without next major bump.
+- **Future majors** track Expo SDK lane bumps (v3 = SDK 57+, etc.) — see [ADR-0005](./adr/0005-sdk-lane-versioning.md).
+
+---
+
+## 10. Non-goals
+
+| Item | Reason |
+| --- | --- |
+| Wrapping Spotify Web API | [ADR-0004](./adr/0004-no-web-api-wrapper.md). Spotify is tightening Web API access. |
+| Spotify Connect device transfer | Web API only. |
+| Web Playback SDK | No web platform. |
+| In-app audio playback | Spotify's model is remote-control of the Spotify app. No exceptions. |
+| Apple Music–style "complete client" facade | Spotify is fundamentally a remote-control + bring-your-own-Web-API model. Don't paper over the architectural difference. |
+
+---
+
+## 11. Risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| App Remote connection lifecycle is flaky in practice (token expiry, Spotify app being killed by OS) | Explicit `connect()` model + clear `CONNECTION_LOST` error code; example app demonstrates reconnect flow. |
+| Premium-required errors are surfaced inconsistently by the SDKs across iOS/Android | Mapper layer per platform normalises to `PREMIUM_REQUIRED`. Document iOS vs Android error-shape differences in error code reference. |
+| Maintaining two SDK lanes in parallel becomes too expensive | Deprecation date for v1 (SDK 55) is left open; can convert to "bug-fix only" at any time. |
+| Spotify ships an SDK update that breaks the bundled xcframework / AAR | Already on ADR-0001 build-time download model; pin the SDK version and bump deliberately. |
+| Spotify Web API tightening makes consumers expect this library to fill the gap | Document the no-Web-API policy prominently. Point consumers at the access token + their own `fetch`. |
+
+---
+
+## 12. Open questions (to revisit during implementation)
+
+- Exact shape of `PlayerState` (which native fields pass through, which get renamed/reshaped) — drafted from iOS `SPTAppRemotePlayerState` headers in Phase 3.
+- Exact shape of `Capabilities` and `LibraryState` — drafted from iOS `SPTAppRemoteUserCapabilities` / `SPTAppRemoteLibraryState` in Phase 4.
+- Exact shape of `ContentItem` recursion (children always known, or lazily fetched per call?) — drafted in Phase 5.
+- `Images.load()` cache strategy — naive temp-file write per call vs cache by URI+size. Default to naive in v1, revisit if size becomes a problem.
+- Whether `connect()` should accept a `refreshFn` callback for SDK-side auto-reconnect on token expiry — out of scope for v1 (consumer handles it), revisit later if it becomes a frequent ask.
+
+---
+
+## Changelog
+
+| Date | Change |
+| --- | --- |
+| 2026-05-27 | Initial v1/v2 plan |

--- a/docs/adr/0004-no-web-api-wrapper.md
+++ b/docs/adr/0004-no-web-api-wrapper.md
@@ -1,0 +1,58 @@
+# ADR-0004: No Web API wrapper
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** @wwdrew
+
+## Context
+
+The Spotify developer surface has three operational layers:
+
+1. **Auth SDK** — `SPTSessionManager` (iOS), `com.spotify.android:auth` (Android). OAuth via the installed Spotify app or web fallback. Returns an access token.
+2. **App Remote SDK** — `SpotifyAppRemote` (iOS), `com.spotify.android:app-remote` (Android). IPC channel to the running Spotify app; controls playback, browses user library state, fetches cover art, walks Spotify's recommended-content tree.
+3. **Web API** — `https://api.spotify.com/v1/*`. REST: catalog search, get-by-id, user's full saved library, recently played, top items, audio features, recommendations, playlist mutations, Spotify Connect device transfer.
+
+Layers 1 and 2 are native SDKs shipped as xcframework / AAR. Layer 3 is REST you call with an OAuth access token.
+
+The library today wraps only layer 1. Looking at comparable cross-platform music libraries (e.g. `@wwdrew/expo-apple-music`), the pattern is to wrap all three layers behind a domain-modelled API (`Catalog`, `Library`, `History`, `Player`, ...). Doing that for Spotify would mean an additional native REST client per platform, a coverage matrix of ~30–50 endpoints, JSON mappers, pagination helpers, error normalisation per endpoint, and ongoing tracking of Spotify's Web API surface.
+
+### Three things pushed against doing that for Spotify
+
+1. **Spotify is actively tightening Web API access.** The [February 2026 migration](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide) restricts Development Mode apps to 5 test users and requires the app owner to hold a Premium subscription. The trajectory is toward more restrictions, not fewer. Wrapping endpoints that may become unavailable or rate-limited differently per consumer is a moving target.
+
+2. **The Apple Music analogue requires the Web API wrapper.** Apple Music's MusicKit (the native SDK) covers playback, auth, and a *subset* of catalog/library reads. The Web API (`api.music.apple.com`) is the only way to do mutations, charts, recommendations endpoints, etc. — so wrapping it is unavoidable if you want a complete client. **Spotify is different**: every "data" feature relevant to a remote-control library lives in App Remote (transport, player state, library state for current track, cover art, recommended-content browsing). The set of features that *only* lives in Web API (search, full catalog, full saved library, recently played, playlist mutations) is genuinely beyond the "control playback in the Spotify app" framing.
+
+3. **The consumer already holds the access token.** `Auth.authenticate()` returns a `SpotifySession` with an OAuth `accessToken`. Calling `fetch("https://api.spotify.com/v1/me", { headers: { Authorization: \`Bearer ${token}\` } })` is one line of JS. The cost of *not* wrapping is small; the cost of *wrapping* (native REST client, mappers, types, error normalisation, two-platform parity, deprecation tracking) is large.
+
+## Decision
+
+**This library wraps only Spotify's native SDKs — the Auth SDK and the App Remote SDK.** It will never wrap the Spotify Web API.
+
+Consumers who need catalog search, full saved library reads, recently played history, top items, audio features, playlist mutations, or Spotify Connect device transfer use the access token from `Auth.authenticate()` to call `https://api.spotify.com/v1/*` themselves with any HTTP client.
+
+## Consequences
+
+### Positive
+
+- Smaller scope, faster to ship, fewer moving parts.
+- Insulated from Spotify Web API restriction tightening — the library's surface doesn't depend on endpoints Spotify may restrict further.
+- Single source of truth for "data": App Remote when it's about controlling the Spotify app, consumer's own Web API calls when it's about anything else. No "is this the App Remote `Content` API or the Web API `/me/top` endpoint?" confusion.
+- Avoids the maintenance burden of a native REST client + JSON mappers + per-endpoint coverage tracking + per-endpoint error normalisation.
+
+### Negative
+
+- Consumers needing Web API features write more code than they would with a wrapper. README needs a "calling the Web API yourself" recipe (basically a `fetch` example with the access token).
+- Consumers comparing this library to comparable wrappers may perceive it as incomplete.
+- If Spotify ever migrates an App Remote capability into Web-API-only territory, that capability disappears from this library and consumers have to write their own Web API call.
+
+### Neutral
+
+- The `Auth.authenticate()` access token is the boundary between "what this library does" and "what consumers do themselves". That boundary is explicit and documented.
+
+## Implementation
+
+Documentation only — no code change. The README, `CONTEXT.md`, and `docs/V1_PLAN.md` all state explicitly that this library does not wrap the Spotify Web API and never will. Consumer-facing recipes in the README for the common Web API patterns (calling `/v1/me`, search, recently played) using the access token with `fetch`.
+
+## Validation
+
+Not applicable — policy decision.

--- a/docs/adr/0005-sdk-lane-versioning.md
+++ b/docs/adr/0005-sdk-lane-versioning.md
@@ -1,0 +1,86 @@
+# ADR-0005: Major versions track Expo SDK lanes
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** @wwdrew
+
+## Context
+
+Expo SDK 56 raised the minimum iOS deployment target from 15.1 to 16.4 and shipped `expo-modules-core@^4.x` with `s.platforms = { :ios => '16.4' }` in its podspec. Any custom Expo module that depends on `expo-modules-core` inherits that floor at install time.
+
+The release before this ADR is `0.8.0`. It targets Expo SDK 55 (iOS 15.1 minimum) via `expo-modules-core@^3.x`. The library is at the same time about to add a large new feature set (App Remote SDK wrapping — see [ADR-0006](./0006-namespaced-api-and-app-remote-scope.md)) which will hit a major version bump regardless of SDK considerations.
+
+Two real constraints collide:
+
+1. **One package version cannot cleanly satisfy both SDK 55 and SDK 56.** CocoaPods resolves the podspec floor strictly. A pod requiring iOS 15.1 will install into an SDK 56 app (the app's floor is higher, that's fine), but a pod requiring iOS 16.4 will fail to install into an SDK 55 app (`expo-modules-core@^3.x` doesn't satisfy the dep). We have to pick one floor in the podspec, and that picks the SDK lane.
+2. **Consumers on SDK 55 are not all able to upgrade.** Many apps have other dependencies pinned to SDK 55, or organisational constraints on Expo SDK bumps, and want App Remote functionality on their current setup rather than waiting until they can bump.
+
+### Options considered
+
+- **One package version, lowest-common-denominator code.** Develop against `expo-modules-core@^3.x` API. Podspec at 15.1. Works on both SDK lanes from one source tree, at the cost of giving up SDK 56's improvements (new JSI layer, Kotlin compiler plugin, prebuilt XCFrameworks) until SDK 55 is dropped from the support matrix. Rejected because the maintainer wants each branch to take full advantage of its SDK lane.
+- **Clean break: v1 = SDK 56 only, no SDK 55 support past 0.8.x.** Simpler maintenance but leaves SDK 55 consumers stuck without App Remote. Rejected because the maintainer explicitly wants SDK 55 consumers to be able to use the App Remote feature set.
+- **Two majors, each pinned to its SDK lane.** `v1.x.x` for SDK 55, `v2.x.x` for SDK 56+. Both ship the full feature set, developed independently per branch.
+
+The pattern of "major version tracks a runtime architecture, not a public-API break" has precedent in the React Native ecosystem — `react-native-mmkv` v3 is the New Architecture line, `react-native-mmkv` v4 is the Nitro Modules line. Consumers pick the major by their runtime, not by API differences.
+
+## Decision
+
+The major version number of this library tracks the supported Expo SDK lane.
+
+- **`v1.x.x`** — Expo SDK 55 and earlier. iOS 15.1 minimum. `expo-modules-core@^3.x`. Lives on the long-lived `v1` branch.
+- **`v2.x.x`** — Expo SDK 56 and higher. iOS 16.4 minimum. `expo-modules-core@^4.x`. Lives on `main`.
+- **`v3.x.x` and beyond** — future SDK-lane bumps.
+
+Both `v1.x.x` and `v2.x.x` ship the full feature set planned for v1 (App Remote SDK wrapping, namespaced API, hooks). Public API is intentionally identical between the two lanes.
+
+The two branches are developed **independently**. There is no lowest-common-denominator rule — each branch uses its SDK lane's full stack (e.g. v2 / main can use SDK 56's new JSI layer and Kotlin compiler plugin freely). Fixes are not auto-ported; the maintainer applies them to each branch as needed.
+
+Each branch has its own pinned example app in `example/` — the v1 branch's example pins to Expo SDK 55, the main branch's example pins to Expo SDK 56.
+
+The deprecation date for `v1.x.x` is **not set**. The maintainer reviews periodically and converts to "bug-fix only" or fully archives when the maintenance cost exceeds the consumer value. This is explicitly a reversible posture — the maintainer can drop the v1 lane at any future point without breaking the versioning scheme.
+
+## Consequences
+
+### Positive
+
+- SDK 55 consumers get App Remote without forcing a runtime upgrade.
+- Each branch uses the best of its SDK lane — no LCD constraint dragging modern branches down.
+- Major version number gives consumers an immediately-readable signal of which SDK lane to install. README states: "`v1.x` for Expo SDK 55, `v2.x` for SDK 56+."
+- Reversible: the maintainer can later freeze v1 / archive v1 / drop SDK 55 entirely without breaking the convention. Future v3 = SDK 57+ slot is open.
+
+### Negative
+
+- Two test matrices, two CI configs, two example apps, two podspec / dev-dep configs.
+- Bug fixes don't auto-port — every fix is two PRs or two cherry-picks. Risk of one branch quietly drifting (gets a fix the other doesn't).
+- Semver expectations are mildly subverted: a major bump signals "runtime change", not "API break". Documented in the README so consumers don't misread it.
+- Consumer discovery: someone landing on the npm page sees the latest version (v2.x) and may not realise v1.x is still maintained. README and the npm `keywords` mention both lanes.
+
+### Neutral
+
+- Public API parity between lanes is a **policy commitment**, not an enforced invariant. The maintainer applies discipline; future tooling could check parity automatically but isn't required for v1.
+
+## Implementation
+
+The branch cut and SDK 56 migration happen **after** all v1.0.0 feature work is complete on `main` (still on SDK 55) — see [V1_PLAN.md §6 Phases 6–7](../V1_PLAN.md#6-implementation-phases). This avoids doing the App Remote work twice.
+
+| Step | Where | When |
+| --- | --- | --- |
+| Develop App Remote + namespacing on `main` while it is still on Expo SDK 55 | `main` | Phases 1–6 |
+| Tag `v1.0.0` on `main` | `main` | End of Phase 6 |
+| Cut `v1` branch from the `v1.0.0` tag | git, branch `v1` | Immediately after tag |
+| `release-please-config.json` on `v1` configured to release `v1.x.y` from `v1` branch | `v1` | Immediately after branch cut |
+| Bump `main` to SDK 56: `ios/ExpoSpotifySDK.podspec` → `:ios, '16.4'`; `package.json` dev deps → `^56`; `example/` pinned to SDK 56 | `main` | Phase 7 |
+| Bump `package.json` version on `main` to `2.0.0` | `main` | Phase 7 |
+| README on both branches documents the lane → version mapping prominently | both | Phases 6 (main / v1) and 7 (main) |
+| CHANGELOG entries reference the lane (`v1.0.0 — Expo SDK 55 lane`, `v2.0.0 — Expo SDK 56 lane`) | both | At release |
+| GitHub Actions runs per branch with the appropriate Xcode / Android SDK matrix | `.github/workflows/` per branch | Phase 7 (main migration); pre-existing on `v1` |
+| Tag `v2.0.0` on `main` | `main` | End of Phase 7 |
+
+## Validation
+
+Not applicable until both branches are cut and a first synchronised release happens. Validation will be:
+
+1. Install v1.x in an Expo SDK 55 app — `npx expo prebuild` succeeds, App Remote calls work.
+2. Install v2.x in an Expo SDK 56 app — same, with SDK 56's faster build.
+3. Install v1.x in an Expo SDK 56 app — pod resolution warns or fails (expected); README directs the consumer to v2.x.
+4. Install v2.x in an Expo SDK 55 app — pod resolution fails (`expo-modules-core@^4` requires iOS 16.4 which the app's other deps can't satisfy); README directs the consumer to v1.x.

--- a/docs/adr/0006-namespaced-api-and-app-remote-scope.md
+++ b/docs/adr/0006-namespaced-api-and-app-remote-scope.md
@@ -1,0 +1,129 @@
+# ADR-0006: Namespaced API and full App Remote SDK scope
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Deciders:** @wwdrew
+
+## Context
+
+`@wwdrew/expo-spotify-sdk@0.8.0` exposes a flat top-level API:
+
+```ts
+import {
+  isAvailable,
+  authenticateAsync,
+  cancelPendingAuthAsync,
+  refreshSessionAsync,
+  addSessionChangeListener,
+  SpotifyError,
+} from "@wwdrew/expo-spotify-sdk";
+```
+
+Five functions, one error class, one event subscription. This shape worked for an auth-only library.
+
+The library is now adding wrappers for the full App Remote SDK (see [V1_PLAN.md](../V1_PLAN.md) for the per-method coverage). App Remote itself decomposes into six native sub-APIs:
+
+| Sub-API | iOS class | What it does |
+| --- | --- | --- |
+| Connection | `SpotifyAppRemote` itself, `SPTAppRemoteConnectionParams` | Connect / disconnect to the Spotify app, auto-launch, lifecycle events. |
+| Player | `SPTAppRemotePlayerAPI` | Transport (`play`, `pause`, `skipNext`, `seek`), queue, shuffle / repeat, playback options. |
+| Player state | `SPTAppRemotePlayerState`, `subscribeToPlayerState` | Live snapshot of current track, position, paused, shuffle, repeat, restrictions, crossfade. |
+| User | `SPTAppRemoteUserAPI` + `SPTAppRemoteUserCapabilities` + `SPTAppRemoteLibraryState` | User capabilities (`canPlayOnDemand`), library state per URI, `addToLibrary` / `removeFromLibrary`. |
+| Content | `SPTAppRemoteContentAPI` | Spotify-curated browse tree (recommended content, navigable as parents / children). |
+| Images | `SPTAppRemoteImageAPI` | Cover art bitmap loader. |
+
+The Android `com.spotify.android:app-remote` SDK has equivalents for all six.
+
+That adds ~25 new methods, ~5 new event subscription streams, and a bunch of new types (`PlayerState`, `Capabilities`, `LibraryState`, `ContentItem`, `RepeatMode`, …) to the public surface. Two shape questions follow:
+
+1. **How is the public API structured** — stay top-level (`play`, `pause`, `connect`, `addToLibrary`, …), or namespace it?
+2. **Which App Remote sub-APIs do we wrap** — all six, or a subset?
+
+### Options considered for (1)
+
+- **Stay flat.** Add ~25 new top-level exports alongside the existing ones. No breaking change. Backwards-compatible.
+- **Namespace fully.** `Auth.authenticate`, `Player.play`, `User.addToLibrary`, ... Six namespaces mirroring the SDK split. Breaking change at the major bump.
+- **Hybrid.** Keep top-level auth functions, namespace only the new App Remote stuff. No breaking change but permanent stylistic inconsistency.
+
+### Options considered for (2)
+
+- **Connection + Player + Player state only.** The minimum credible App Remote wrapper. Defer User / Content / Images to point releases.
+- **All six.** Wrap every documented App Remote sub-API. No consumer ever drops to native to use a missing feature.
+- **Connection + Player + Player state + User + Images (skip Content).** Compromise — Content is the most opinionated and most overlap with what the Spotify app itself shows.
+
+## Decision
+
+### Six namespaces
+
+The public API is split into six namespaces, each named for the underlying SDK area:
+
+```ts
+import { Auth, AppRemote, Player, User, Content, Images } from "@wwdrew/expo-spotify-sdk";
+```
+
+| Namespace | Wraps |
+| --- | --- |
+| `Auth` | OAuth (today's top-level functions). |
+| `AppRemote` | Connection lifecycle (`connect`, `disconnect`, connection state events). |
+| `Player` | Transport, queue, player state subscription. |
+| `User` | Capabilities, per-URI library state, saves. |
+| `Content` | Curated content browsing. |
+| `Images` | Cover art loader. |
+
+The flat top-level functions from v0.x are **removed**, not soft-deprecated. Migration is a mechanical rename — see [V1_PLAN.md §8](../V1_PLAN.md#8-migration-from-v0x). The major bump is the right time to do this; carrying both shapes forever would mean permanent two-stylistic-worlds drift.
+
+Naming style across namespaces:
+
+- Drop the `Async` suffix from method names. The Promise return type carries the info.
+- Subscription methods use a typed-generic `addListener<K extends keyof EventMap>(event, cb)` pattern for type-safe events. The `EventMap` per namespace documents which streams exist.
+- Connection-dependent methods (everything in `Player` / `User` / `Content` / `Images`) reject with the namespace's `NOT_CONNECTED` error code if called before `AppRemote.connect()` resolved.
+
+### All six App Remote sub-APIs
+
+v1.0.0 / v2.0.0 wrap **every documented App Remote sub-API**. Partial coverage would leave consumers reaching for native code for any feature we skipped — which defeats the point of having a wrapper at all.
+
+This includes the `Content` and `Images` APIs even though they're the most "data-like" and would be easiest to defer. They are part of App Remote, they're what the SDK ships, and they have no alternative source for the consumer (the Web API exposes catalog / saved-library data but not Spotify's curated content tree or App-Remote-resolved cover art).
+
+## Consequences
+
+### Positive
+
+- Public API mirrors the underlying SDK structure 1:1. A consumer reading Spotify's official docs can map every concept to a namespace in this library.
+- Discoverable via IDE autocomplete — typing `Auth.` / `Player.` / etc. surfaces all available methods. No giant flat top-level list.
+- Type-safe events through `addListener<K>` keep the JS / native event surface readable.
+- No "what's missing?" question — every native sub-API has a wrapper.
+
+### Negative
+
+- Breaking change for every v0.x consumer. Migration is mechanical (rename `authenticateAsync` → `Auth.authenticate`, etc.) but it is breaking.
+- More native code to write and maintain — every namespace gets a Swift module, a Kotlin module, an iOS exception subclass, an Android `CodedException` subclass.
+- Three new namespaces (`Content`, `Images`, parts of `User`) are less essential than `Player` — the cost to v1 is real even though we believe the benefit justifies it.
+
+### Neutral
+
+- Hooks live as top-level exports (`useSession`, `usePlayerState`, ...), not under their namespace. Idiomatic React hook discoverability outweighs naming consistency with the underlying namespace.
+
+## Implementation
+
+The phased plan (Phase 0 → Phase 6) lives in [V1_PLAN.md §6](../V1_PLAN.md#6-implementation-phases). Highlights:
+
+| Phase | What |
+| --- | --- |
+| 1 | Foundation: error classes, `SpotifyURI` branded type, namespace skeletons, auth migration. |
+| 2 | `AppRemote` connection lifecycle on both platforms. |
+| 3 | `Player` transport + player state subscription + hooks. |
+| 4 | `User` capabilities + library state. |
+| 5 | `Content` + `Images`. |
+| 6 | Hardening, README rewrite, example app polish. |
+
+Each phase lands on both `main` (v2 / SDK 56) and `v1` (SDK 55) per [ADR-0005](./0005-sdk-lane-versioning.md).
+
+## Validation
+
+Per-phase exit criteria in [V1_PLAN.md §6](../V1_PLAN.md#6-implementation-phases). Final release criteria in [V1_PLAN.md §9](../V1_PLAN.md#9-v100--v200-release-criteria) — both v1.0.0 and v2.0.0 require:
+
+- Every method `✅` on iOS and Android in the coverage matrix.
+- Example app demonstrating all six namespaces (Auth, AppRemote connect/disconnect, Player transport + now-playing state via hooks, User save gated by capabilities, Content browse, Images load).
+- README rewritten with new API + migration table.
+- Every error code documented with "when" and "what to do".
+- Manual QA on real devices, Premium and Free accounts, both platforms.


### PR DESCRIPTION
Establishes project domain language and the full v1/v2 plan for App
Remote SDK wrapping:

- CONTEXT.md — glossary covering Auth SDK, App Remote SDK, Web API,
  connection lifecycle, SpotifyURI branded type, error class hierarchy,
  and the explicit no-web-api-wrapper boundary
- docs/V1_PLAN.md — living plan covering all six namespaces (Auth,
  AppRemote, Player, User, Content, Images), hooks, error code
  reference, coverage matrix, implementation phases 0–7 (including the
  branch-cut-then-SDK-56-migration sequence), migration table from
  v0.x, and release criteria for v1.0.0 and v2.0.0
- ADR-0004 — no Spotify Web API wrapper, ever
- ADR-0005 — major versions track Expo SDK lanes (v1.x = SDK 55,
  v2.x = SDK 56+); branch cut happens after v1.0.0 is feature-complete
- ADR-0006 — six-namespace API and full App Remote sub-API scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added architecture decision records and comprehensive v1.0.0 release roadmap
* Established versioning strategy aligned with Expo SDK lanes (v1 supports SDK 55, v2 supports SDK 56+)
* Documented planned API redesign with Auth, AppRemote, Player, User, Content, and Images namespaces
* Clarified library boundaries: supports native Spotify SDKs only, Web API not included

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wwdrew/expo-spotify-sdk/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->