### PR TITLE
feat(api): Phase 1 — namespace skeleton, error hierarchy, SpotifyURI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,6 +6,10 @@ Reference for humans and agents. Use this file to keep terminology straight when
 
 This repo uses [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description` (e.g. `fix(ios): …`, `feat(android): …`, `docs: …`). Use an optional scope when the change is platform- or area-specific.
 
+## Branch naming
+
+Branch names follow the same `type/` prefix as conventional commits: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`, `test/*`. Examples: `feat/auth-namespace`, `fix/android-token-flow`, `docs/v1-plan`.
+
 ## Terminology
 
 | Term | Meaning | **Not** this |
@@ -31,13 +35,13 @@ This repo uses [Conventional Commits](https://www.conventionalcommits.org/): `ty
 
 ## v1.0.0 direction
 
-`v1.0.0` adds App Remote support (transport, now-playing, hooks) on top of the existing Auth surface, drops support for iOS deployment targets older than what Expo SDK 56 requires, and is the cutoff for the last `v0.x` release that supports SDK 55 and earlier.
+`v1.0.0` adds App Remote support (transport, now-playing, hooks) on top of the existing Auth surface. It targets Expo SDK 55 (iOS 15.1+). See [ADR-0005](./docs/adr/0005-sdk-lane-versioning.md) for the lane versioning strategy.
 
-**Explicitly not in v1:**
+**Explicitly not in v1 (or any version):**
 
 - Spotify Web API wrappers (catalog, library reads, recently played, top items, recommendations, playlist mutations) — consumers call REST themselves with the access token. Spotify is tightening Web API access (see [Feb 2026 migration](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide)) and we don't want to be on the hook for that surface.
 - Spotify Connect device transfer / device list — Web API only.
-- Web platform / Web Playback SDK — native SDKs only.
+- Web platform — this library targets iOS and Android only. There is no web support and none is planned.
 - Any in-app audio playback — Spotify's model is "remote-control the Spotify app". No exceptions.
 
 ## Related docs

--- a/src/ExpoSpotifySDKModule.web.ts
+++ b/src/ExpoSpotifySDKModule.web.ts
@@ -1,9 +1,7 @@
-import { SpotifyError } from "./ExpoSpotifySDK.types";
-
-function notImplementedReject(method: string): SpotifyError {
-  return new SpotifyError(
-    "INVALID_CONFIG",
-    `expo-spotify-sdk: ${method} is not implemented on web yet (planned for v0.7.0).`,
+function unsupported(method: string): Error {
+  return new Error(
+    `[expo-spotify-sdk] ${method} is not supported on web. ` +
+      "This library targets iOS and Android only.",
   );
 }
 
@@ -12,10 +10,10 @@ export default {
     return false;
   },
   authenticateAsync(): Promise<never> {
-    return Promise.reject(notImplementedReject("authenticateAsync"));
+    return Promise.reject(unsupported("authenticateAsync"));
   },
   refreshSessionAsync(): Promise<never> {
-    return Promise.reject(notImplementedReject("refreshSessionAsync"));
+    return Promise.reject(unsupported("refreshSessionAsync"));
   },
   addListener(): { remove(): void } {
     return { remove() {} };

--- a/src/app-remote/error.ts
+++ b/src/app-remote/error.ts
@@ -1,0 +1,17 @@
+import { SpotifyError } from "../error";
+
+export type AppRemoteErrorCode =
+  | "CONNECTION_FAILED"
+  | "CONNECTION_LOST"
+  | "NOT_CONNECTED"
+  | "UNKNOWN";
+
+export class AppRemoteError extends SpotifyError {
+  readonly namespace = "AppRemote" as const;
+  readonly code: AppRemoteErrorCode;
+
+  constructor(code: AppRemoteErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/app-remote/index.ts
+++ b/src/app-remote/index.ts
@@ -1,0 +1,27 @@
+export type { AppRemoteErrorCode } from "./error";
+export { AppRemoteError } from "./error";
+
+// ---------------------------------------------------------------------------
+// AppRemote types (stubs — filled in Phase 2)
+// ---------------------------------------------------------------------------
+
+/** Current state of the IPC connection to the Spotify app. */
+export type ConnectionState = "disconnected" | "connecting" | "connected";
+
+// ---------------------------------------------------------------------------
+// AppRemote namespace (stub — implemented in Phase 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Spotify App Remote namespace. Manages the IPC connection to the running
+ * Spotify app. All `Player`, `User`, `Content`, and `Images` calls require
+ * an active connection established via `AppRemote.connect()`.
+ *
+ * @example
+ * ```ts
+ * import { AppRemote } from "@wwdrew/expo-spotify-sdk";
+ *
+ * await AppRemote.connect(session.accessToken);
+ * ```
+ */
+export const AppRemote = {} as const;

--- a/src/auth/error.ts
+++ b/src/auth/error.ts
@@ -1,0 +1,22 @@
+import { SpotifyError } from "../error";
+
+export type AuthErrorCode =
+  | "USER_CANCELLED"
+  | "AUTH_IN_PROGRESS"
+  | "INVALID_CONFIG"
+  | "NETWORK_ERROR"
+  | "TOKEN_SWAP_FAILED"
+  | "TOKEN_SWAP_PARSE_ERROR"
+  | "SPOTIFY_NOT_INSTALLED"
+  | "AUTH_ERROR"
+  | "UNKNOWN";
+
+export class AuthError extends SpotifyError {
+  readonly namespace = "Auth" as const;
+  readonly code: AuthErrorCode;
+
+  constructor(code: AuthErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,273 @@
+import { EventSubscription, Platform } from "expo-modules-core";
+
+import ExpoSpotifySDKModule from "../ExpoSpotifySDKModule";
+import { AuthError, AuthErrorCode } from "./error";
+
+export type { AuthErrorCode } from "./error";
+export { AuthError } from "./error";
+
+// ---------------------------------------------------------------------------
+// Auth-specific types
+// ---------------------------------------------------------------------------
+
+export interface SpotifySession {
+  /** OAuth access token. */
+  accessToken: string;
+  /**
+   * OAuth refresh token. `null` on Android when no `tokenSwapURL` is provided
+   * (the Spotify Android SDK does not expose a refresh token for implicit
+   * grants).
+   */
+  refreshToken: string | null;
+  /** Expiration timestamp as Unix epoch milliseconds. */
+  expirationDate: number;
+  /** Scopes the access token was granted (or requested, on Android implicit). */
+  scopes: SpotifyScope[];
+}
+
+export type SpotifyScope =
+  | "ugc-image-upload"
+  | "user-read-playback-state"
+  | "user-modify-playback-state"
+  | "user-read-currently-playing"
+  | "app-remote-control"
+  | "streaming"
+  | "playlist-read-private"
+  | "playlist-read-collaborative"
+  | "playlist-modify-private"
+  | "playlist-modify-public"
+  | "user-follow-modify"
+  | "user-follow-read"
+  | "user-top-read"
+  | "user-read-recently-played"
+  | "user-library-modify"
+  | "user-library-read"
+  | "user-read-email"
+  | "user-read-private";
+
+export interface AuthenticateConfig {
+  /** OAuth scopes to request. Must contain at least one entry. */
+  scopes: SpotifyScope[];
+  /**
+   * If supplied, requests an authorization code rather than an implicit
+   * token, then POSTs the code to this URL to exchange it for tokens.
+   * **Required on Android** to receive a usable `refreshToken`.
+   */
+  tokenSwapURL?: string;
+  /**
+   * Used by the iOS SDK to refresh access tokens automatically, and by
+   * `Auth.refresh()` on both platforms.
+   */
+  tokenRefreshURL?: string;
+  /**
+   * If `true`, forces Spotify to show the authorization dialog even when the
+   * user already has an active session. Defaults to `false`.
+   */
+  showDialog?: boolean;
+}
+
+export interface RefreshConfig {
+  /** The refresh token from a previous `Auth.authenticate()` call. */
+  refreshToken: string;
+  /** URL of your token refresh server endpoint. */
+  tokenRefreshURL: string;
+  /**
+   * Scopes that were granted by the previous session. Used as a fallback when
+   * the refresh response omits the `scope` field.
+   */
+  scopes?: SpotifyScope[];
+}
+
+/**
+ * Payload delivered to `Auth.addListener("sessionChange", ...)` subscribers.
+ */
+export type SessionChangeEvent =
+  | { type: "didInitiate"; session: SpotifySession }
+  | { type: "didRenew"; session: SpotifySession }
+  | { type: "didFail"; error: { code: AuthErrorCode; message: string } };
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const ANDROID_TOKEN_FLOW_WARNING =
+  "[expo-spotify-sdk] You are using Auth.authenticate on Android without a " +
+  "tokenSwapURL. The Spotify Android SDK does NOT return a refresh token or " +
+  "the actual granted scopes through this path; see the README's " +
+  "'Android implicit (TOKEN) flow is not recommended' section.";
+
+let warnedAboutAndroidTokenFlow = false;
+
+const VALID_AUTH_CODES = new Set<AuthErrorCode>([
+  "USER_CANCELLED",
+  "AUTH_IN_PROGRESS",
+  "INVALID_CONFIG",
+  "NETWORK_ERROR",
+  "TOKEN_SWAP_FAILED",
+  "TOKEN_SWAP_PARSE_ERROR",
+  "SPOTIFY_NOT_INSTALLED",
+  "AUTH_ERROR",
+  "UNKNOWN",
+]);
+
+const CAUSE_SEPARATOR = "→ Caused by: ";
+const LEGACY_CODE_PREFIX_RE = /^([A-Z_][A-Z0-9_]*):\s*(.*)$/s;
+
+function unwrapReason(message: string): string {
+  const idx = message.lastIndexOf(CAUSE_SEPARATOR);
+  return idx === -1 ? message : message.slice(idx + CAUSE_SEPARATOR.length);
+}
+
+function rethrowAsAuthError(err: unknown): never {
+  if (err instanceof AuthError) throw err;
+  if (err instanceof Error) {
+    const reason = unwrapReason(err.message);
+    const maybeCode = (err as Error & { code?: string }).code;
+    if (maybeCode && VALID_AUTH_CODES.has(maybeCode as AuthErrorCode)) {
+      throw new AuthError(maybeCode as AuthErrorCode, reason);
+    }
+    const m = reason.match(LEGACY_CODE_PREFIX_RE);
+    if (m && VALID_AUTH_CODES.has(m[1] as AuthErrorCode)) {
+      throw new AuthError(m[1] as AuthErrorCode, m[2]);
+    }
+    throw new AuthError("UNKNOWN", reason);
+  }
+  throw new AuthError("UNKNOWN", String(err));
+}
+
+function normaliseSession(raw: unknown): SpotifySession {
+  if (!raw || typeof raw !== "object") {
+    throw new AuthError("UNKNOWN", "Native module returned a non-object session");
+  }
+  const r = raw as Record<string, unknown>;
+  const accessToken = r.accessToken;
+  if (typeof accessToken !== "string" || accessToken.length === 0) {
+    throw new AuthError("UNKNOWN", "Session is missing accessToken");
+  }
+  const expirationDate = r.expirationDate;
+  if (typeof expirationDate !== "number") {
+    throw new AuthError("UNKNOWN", "Session is missing expirationDate");
+  }
+  const refreshTokenRaw = r.refreshToken;
+  const refreshToken =
+    typeof refreshTokenRaw === "string" && refreshTokenRaw.length > 0
+      ? refreshTokenRaw
+      : null;
+  const scopesRaw = r.scopes;
+  const scopes = Array.isArray(scopesRaw)
+    ? (scopesRaw.filter((s) => typeof s === "string") as SpotifyScope[])
+    : [];
+  return { accessToken, refreshToken, expirationDate, scopes };
+}
+
+// ---------------------------------------------------------------------------
+// Auth namespace
+// ---------------------------------------------------------------------------
+
+/**
+ * Spotify Auth namespace. Handles OAuth authentication and session lifecycle.
+ *
+ * @example
+ * ```ts
+ * import { Auth } from "@wwdrew/expo-spotify-sdk";
+ *
+ * const session = await Auth.authenticate({ scopes: ["streaming"] });
+ * ```
+ */
+export const Auth = {
+  /**
+   * Returns `true` if the Spotify app is installed on the device.
+   */
+  isAvailable(): boolean {
+    return ExpoSpotifySDKModule.isAvailable();
+  },
+
+  /**
+   * Starts a Spotify OAuth flow. Resolves with a {@link SpotifySession};
+   * rejects with an {@link AuthError} carrying a `code`.
+   */
+  authenticate(config: AuthenticateConfig): Promise<SpotifySession> {
+    if (!config.scopes || config.scopes.length === 0) {
+      return Promise.reject(
+        new AuthError("INVALID_CONFIG", "scopes must contain at least one entry"),
+      );
+    }
+    if (
+      Platform.OS === "android" &&
+      !config.tokenSwapURL &&
+      !warnedAboutAndroidTokenFlow
+    ) {
+      warnedAboutAndroidTokenFlow = true;
+      console.warn(ANDROID_TOKEN_FLOW_WARNING);
+    }
+    return ExpoSpotifySDKModule.authenticateAsync(config)
+      .then(normaliseSession)
+      .catch(rethrowAsAuthError);
+  },
+
+  /**
+   * Exchanges a refresh token for a new access token via your token refresh
+   * server. Resolves with a fresh {@link SpotifySession}; rejects with an
+   * {@link AuthError}.
+   */
+  refresh(config: RefreshConfig): Promise<SpotifySession> {
+    if (!config.refreshToken) {
+      return Promise.reject(
+        new AuthError("INVALID_CONFIG", "refreshToken is required"),
+      );
+    }
+    if (!config.tokenRefreshURL) {
+      return Promise.reject(
+        new AuthError("INVALID_CONFIG", "tokenRefreshURL is required"),
+      );
+    }
+    return ExpoSpotifySDKModule.refreshSessionAsync(config)
+      .then(normaliseSession)
+      .catch(rethrowAsAuthError);
+  },
+
+  /**
+   * Forcibly cancel any in-flight `Auth.authenticate()` call. No-op on
+   * Android (the Android coordinator self-cleans via structured concurrency).
+   *
+   * Use before `Auth.authenticate()` to defensively clear any leaked iOS
+   * coordinator state (the `SPTSessionManager` delegate callbacks are not
+   * guaranteed to fire).
+   */
+  cancelPending(): Promise<void> {
+    if (Platform.OS !== "ios") {
+      return Promise.resolve();
+    }
+    return ExpoSpotifySDKModule.cancelPendingAuthAsync();
+  },
+
+  /**
+   * Subscribes to session lifecycle events.
+   *
+   * Events fire for every `Auth.authenticate()` and `Auth.refresh()` call,
+   * regardless of whether the call was awaited. Useful for persisting tokens
+   * in a central store without coupling the store to the call sites.
+   *
+   * Returns a `Subscription` — call `.remove()` to unsubscribe.
+   *
+   * @example
+   * ```ts
+   * const sub = Auth.addListener("sessionChange", (event) => {
+   *   if (event.type === "didInitiate" || event.type === "didRenew") {
+   *     store.setSession(event.session);
+   *   }
+   * });
+   * // later:
+   * sub.remove();
+   * ```
+   */
+  addListener(
+    event: "sessionChange",
+    listener: (event: SessionChangeEvent) => void,
+  ): EventSubscription {
+    return ExpoSpotifySDKModule.addListener(
+      "onSessionChange",
+      listener,
+    ) as EventSubscription;
+  },
+} as const;

--- a/src/content/error.ts
+++ b/src/content/error.ts
@@ -1,0 +1,17 @@
+import { SpotifyError } from "../error";
+
+export type ContentErrorCode =
+  | "NOT_CONNECTED"
+  | "CONNECTION_LOST"
+  | "CONTENT_API_UNAVAILABLE"
+  | "UNKNOWN";
+
+export class ContentError extends SpotifyError {
+  readonly namespace = "Content" as const;
+  readonly code: ContentErrorCode;
+
+  constructor(code: ContentErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,0 +1,19 @@
+export type { ContentErrorCode } from "./error";
+export { ContentError } from "./error";
+
+// ---------------------------------------------------------------------------
+// Content namespace (stub — implemented in Phase 5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Spotify Content namespace. Browse Spotify's curated content tree.
+ * Requires `AppRemote.connect()` to be resolved before any call.
+ *
+ * @example
+ * ```ts
+ * import { Content } from "@wwdrew/expo-spotify-sdk";
+ *
+ * const items = await Content.getRecommendedContentItems("default");
+ * ```
+ */
+export const Content = {} as const;

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,27 @@
+/**
+ * Abstract base class for every error thrown by this library. Carry a
+ * structured `code` and a `namespace` so catch-all handlers can branch
+ * without importing concrete subclasses.
+ *
+ * Always thrown as one of the per-namespace subclasses:
+ * `AuthError`, `AppRemoteError`, `PlayerError`, `UserError`,
+ * `ContentError`, `ImagesError`.
+ *
+ * @example
+ * ```ts
+ * try { ... } catch (e) {
+ *   if (e instanceof SpotifyError) {
+ *     console.error(e.namespace, e.code, e.message);
+ *   }
+ * }
+ * ```
+ */
+export abstract class SpotifyError extends Error {
+  abstract readonly code: string;
+  abstract readonly namespace: string;
+
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/src/images/error.ts
+++ b/src/images/error.ts
@@ -1,0 +1,17 @@
+import { SpotifyError } from "../error";
+
+export type ImagesErrorCode =
+  | "NOT_CONNECTED"
+  | "INVALID_URI"
+  | "IMAGE_LOAD_FAILED"
+  | "UNKNOWN";
+
+export class ImagesError extends SpotifyError {
+  readonly namespace = "Images" as const;
+  readonly code: ImagesErrorCode;
+
+  constructor(code: ImagesErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/images/index.ts
+++ b/src/images/index.ts
@@ -1,0 +1,20 @@
+export type { ImagesErrorCode } from "./error";
+export { ImagesError } from "./error";
+
+// ---------------------------------------------------------------------------
+// Images namespace (stub — implemented in Phase 5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Spotify Images namespace. Fetches cover art for tracks, albums, artists,
+ * and content items via the App Remote SDK, writing the bitmap to a temp file
+ * and returning its local URI. Requires `AppRemote.connect()` to be resolved.
+ *
+ * @example
+ * ```ts
+ * import { Images } from "@wwdrew/expo-spotify-sdk";
+ *
+ * const { uri } = await Images.load(track, "large");
+ * ```
+ */
+export const Images = {} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,226 +1,102 @@
-import { EventSubscription, Platform } from "expo-modules-core";
+// ---------------------------------------------------------------------------
+// Namespaces (v1 public API)
+// ---------------------------------------------------------------------------
 
-import {
-  SpotifyConfig,
-  SpotifyError,
-  SpotifyErrorCode,
-  SpotifyRefreshConfig,
-  SpotifySession,
-  SpotifySessionChangeEvent,
-} from "./ExpoSpotifySDK.types";
-import ExpoSpotifySDKModule from "./ExpoSpotifySDKModule";
+export { Auth } from "./auth";
+export { AppRemote } from "./app-remote";
+export { Player } from "./player";
+export { User } from "./user";
+export { Content } from "./content";
+export { Images } from "./images";
 
-const ANDROID_TOKEN_FLOW_WARNING =
-  "[expo-spotify-sdk] You are using authenticateAsync on Android without a " +
-  "tokenSwapURL. The Spotify Android SDK does NOT return a refresh token or " +
-  "the actual granted scopes through this path; see the README's " +
-  "'Android implicit (TOKEN) flow is not recommended' section.";
+// ---------------------------------------------------------------------------
+// Error hierarchy
+// ---------------------------------------------------------------------------
 
-let warnedAboutAndroidTokenFlow = false;
+export { SpotifyError } from "./error";
+export { AuthError } from "./auth";
+export { AppRemoteError } from "./app-remote";
+export { PlayerError } from "./player";
+export { UserError } from "./user";
+export { ContentError } from "./content";
+export { ImagesError } from "./images";
 
-/**
- * Returns `true` if the Spotify app is installed on the device.
- * Always returns `false` on web.
- */
-function isAvailable(): boolean {
-  return ExpoSpotifySDKModule.isAvailable();
-}
+// ---------------------------------------------------------------------------
+// Error code types
+// ---------------------------------------------------------------------------
 
-/**
- * Starts a Spotify OAuth flow. Resolves with a {@link SpotifySession};
- * rejects with a {@link SpotifyError} carrying a `code`.
- */
-function authenticateAsync(config: SpotifyConfig): Promise<SpotifySession> {
-  if (!config.scopes || config.scopes.length === 0) {
-    return Promise.reject(
-      new SpotifyError(
-        "INVALID_CONFIG",
-        "scopes must contain at least one entry",
-      ),
-    );
-  }
-  if (
-    Platform.OS === "android" &&
-    !config.tokenSwapURL &&
-    !warnedAboutAndroidTokenFlow
-  ) {
-    warnedAboutAndroidTokenFlow = true;
+export type { AuthErrorCode } from "./auth";
+export type { AppRemoteErrorCode } from "./app-remote";
+export type { PlayerErrorCode } from "./player";
+export type { UserErrorCode } from "./user";
+export type { ContentErrorCode } from "./content";
+export type { ImagesErrorCode } from "./images";
 
-    console.warn(ANDROID_TOKEN_FLOW_WARNING);
-  }
-  return ExpoSpotifySDKModule.authenticateAsync(config)
-    .then(normaliseSession)
-    .catch(rethrowAsSpotifyError);
-}
+// ---------------------------------------------------------------------------
+// URI helpers
+// ---------------------------------------------------------------------------
 
-/**
- * Forcibly cancel any in-flight `authenticateAsync` call. Resolves once the
- * native coordinator's pending continuation has been cleared. No-op when
- * nothing is in flight, and a no-op on Android (the Android coordinator
- * self-cleans via structured concurrency).
- *
- * Recovery hatch for the iOS coordinator's stuck-state class of bugs: the
- * SPTSessionManager delegate callbacks are not guaranteed to fire — e.g. when
- * Spotify never redirects back to the host app — leaving the coordinator's
- * `pending` continuation set forever and every subsequent `authenticateAsync`
- * rejecting with `AUTH_IN_PROGRESS` until the process restarts. Call this
- * before `authenticateAsync` to defensively clear any leaked state.
- */
-function cancelPendingAuthAsync(): Promise<void> {
-  if (Platform.OS !== "ios") {
-    return Promise.resolve();
-  }
-  return ExpoSpotifySDKModule.cancelPendingAuthAsync();
-}
+export { SpotifyURI } from "./uri";
+export type { SpotifyResourceType, SpotifyURI as SpotifyURIType } from "./uri";
 
-function normaliseSession(raw: unknown): SpotifySession {
-  if (!raw || typeof raw !== "object") {
-    throw new SpotifyError(
-      "UNKNOWN",
-      "Native module returned a non-object session",
-    );
-  }
-  const r = raw as Record<string, unknown>;
-  const accessToken = r.accessToken;
-  if (typeof accessToken !== "string" || accessToken.length === 0) {
-    throw new SpotifyError("UNKNOWN", "Session is missing accessToken");
-  }
-  const expirationDate = r.expirationDate;
-  if (typeof expirationDate !== "number") {
-    throw new SpotifyError("UNKNOWN", "Session is missing expirationDate");
-  }
-  const refreshTokenRaw = r.refreshToken;
-  const refreshToken =
-    typeof refreshTokenRaw === "string" && refreshTokenRaw.length > 0
-      ? refreshTokenRaw
-      : null;
-  const scopesRaw = r.scopes;
-  const scopes = Array.isArray(scopesRaw)
-    ? (scopesRaw.filter(
-        (s) => typeof s === "string",
-      ) as SpotifySession["scopes"])
-    : [];
-  return { accessToken, refreshToken, expirationDate, scopes };
-}
+// ---------------------------------------------------------------------------
+// Auth types
+// ---------------------------------------------------------------------------
 
-/**
- * Exchanges a refresh token for a new access token via your token refresh
- * server. Resolves with a fresh {@link SpotifySession}; rejects with a
- * {@link SpotifyError}.
- */
-function refreshSessionAsync(
-  config: SpotifyRefreshConfig,
-): Promise<SpotifySession> {
-  if (!config.refreshToken) {
-    return Promise.reject(
-      new SpotifyError("INVALID_CONFIG", "refreshToken is required"),
-    );
-  }
-  if (!config.tokenRefreshURL) {
-    return Promise.reject(
-      new SpotifyError("INVALID_CONFIG", "tokenRefreshURL is required"),
-    );
-  }
-  return ExpoSpotifySDKModule.refreshSessionAsync(config)
-    .then(normaliseSession)
-    .catch(rethrowAsSpotifyError);
-}
-
-/**
- * Subscribes to session lifecycle events emitted by the native module.
- *
- * Events are fired for every `authenticateAsync` and `refreshSessionAsync`
- * call, regardless of whether the call was awaited. Useful for persisting
- * tokens in a central store without coupling the store to the call sites.
- *
- * Returns a {@link Subscription} — call `.remove()` to unsubscribe.
- *
- * @example
- * ```ts
- * const sub = addSessionChangeListener((event) => {
- *   if (event.type === "didInitiate" || event.type === "didRenew") {
- *     store.setSession(event.session);
- *   }
- * });
- * // later:
- * sub.remove();
- * ```
- */
-function addSessionChangeListener(
-  listener: (event: SpotifySessionChangeEvent) => void,
-): EventSubscription {
-  return ExpoSpotifySDKModule.addListener(
-    "onSessionChange",
-    listener,
-  ) as EventSubscription;
-}
-
-const VALID_CODES: ReadonlySet<SpotifyErrorCode> = new Set<SpotifyErrorCode>([
-  "USER_CANCELLED",
-  "AUTH_IN_PROGRESS",
-  "INVALID_CONFIG",
-  "NETWORK_ERROR",
-  "TOKEN_SWAP_FAILED",
-  "TOKEN_SWAP_PARSE_ERROR",
-  "SPOTIFY_NOT_INSTALLED",
-  "AUTH_ERROR",
-  "UNKNOWN",
-]);
-
-// expo-modules-core wraps both iOS `Exception`s and Android `CodedException`s
-// in a function-call-level decorator that prepends a platform-specific
-// prefix (e.g. "Calling the 'authenticateAsync' function has failed" on iOS,
-// "Call to function 'ExpoSpotifySDK.authenticateAsync' has been rejected." on
-// Android) and joins the original reason with the canonical "→ Caused by: "
-// separator. Strip the wrapper so JS consumers see only the native module's
-// own reason — `code` is preserved structurally either way.
-const CAUSE_SEPARATOR = "→ Caused by: ";
-
-// Legacy fallback for native modules that don't propagate `code` — pre-0.9
-// iOS shipped `GenericException("<CODE>: <msg>")`, surfacing as a literal
-// "CODE: message" prefix in `err.message` with no structured code.
-const LEGACY_CODE_PREFIX_RE = /^([A-Z_][A-Z0-9_]*):\s*(.*)$/s;
-
-function unwrapReason(message: string): string {
-  const idx = message.lastIndexOf(CAUSE_SEPARATOR);
-  return idx === -1 ? message : message.slice(idx + CAUSE_SEPARATOR.length);
-}
-
-function rethrowAsSpotifyError(err: unknown): never {
-  if (err instanceof SpotifyError) throw err;
-  if (err instanceof Error) {
-    const reason = unwrapReason(err.message);
-    const maybeCode = (err as Error & { code?: string }).code;
-    if (maybeCode && VALID_CODES.has(maybeCode as SpotifyErrorCode)) {
-      throw new SpotifyError(maybeCode as SpotifyErrorCode, reason);
-    }
-    const m = reason.match(LEGACY_CODE_PREFIX_RE);
-    if (m && VALID_CODES.has(m[1] as SpotifyErrorCode)) {
-      throw new SpotifyError(m[1] as SpotifyErrorCode, m[2]);
-    }
-    throw new SpotifyError("UNKNOWN", reason);
-  }
-  throw new SpotifyError("UNKNOWN", String(err));
-}
-
-const Authenticate = {
-  authenticateAsync,
-};
-
-export {
-  isAvailable,
-  authenticateAsync,
-  cancelPendingAuthAsync,
-  refreshSessionAsync,
-  addSessionChangeListener,
-  Authenticate,
-  SpotifyError,
-};
 export type {
-  SpotifyConfig,
-  SpotifyRefreshConfig,
   SpotifySession,
-  SpotifySessionChangeEvent,
-  SpotifyErrorCode,
   SpotifyScope,
-} from "./ExpoSpotifySDK.types";
+  AuthenticateConfig,
+  RefreshConfig,
+  SessionChangeEvent,
+} from "./auth";
+
+// ---------------------------------------------------------------------------
+// v0.x backward-compatible exports (deprecated — remove at v2.0.0)
+//
+// These shims let existing callers continue to compile after upgrading to v1.
+// Migrate to the namespaced API: see docs/V1_PLAN.md §8 (Migration).
+// ---------------------------------------------------------------------------
+
+import { Auth } from "./auth";
+import type {
+  AuthenticateConfig as SpotifyConfig,
+  RefreshConfig as SpotifyRefreshConfig,
+} from "./auth";
+
+/** @deprecated Use `Auth.isAvailable()` */
+export function isAvailable(): boolean {
+  return Auth.isAvailable();
+}
+
+/** @deprecated Use `Auth.authenticate(config)` */
+export function authenticateAsync(config: SpotifyConfig) {
+  return Auth.authenticate(config);
+}
+
+/** @deprecated Use `Auth.cancelPending()` */
+export function cancelPendingAuthAsync() {
+  return Auth.cancelPending();
+}
+
+/** @deprecated Use `Auth.refresh(config)` */
+export function refreshSessionAsync(config: SpotifyRefreshConfig) {
+  return Auth.refresh(config);
+}
+
+/** @deprecated Use `Auth.addListener("sessionChange", cb)` */
+export function addSessionChangeListener(
+  listener: Parameters<typeof Auth.addListener>[1],
+) {
+  return Auth.addListener("sessionChange", listener);
+}
+
+// Re-export legacy type aliases so existing `import type { SpotifyConfig }`
+// consumers don't break.
+export type { SpotifyConfig, SpotifyRefreshConfig };
+
+/**
+ * @deprecated `SpotifyErrorCode` is now `AuthErrorCode`. Import via:
+ * `import type { AuthErrorCode } from "@wwdrew/expo-spotify-sdk"`
+ */
+export type { AuthErrorCode as SpotifyErrorCode } from "./auth";

--- a/src/player/error.ts
+++ b/src/player/error.ts
@@ -1,0 +1,20 @@
+import { SpotifyError } from "../error";
+
+export type PlayerErrorCode =
+  | "NOT_CONNECTED"
+  | "CONNECTION_LOST"
+  | "PREMIUM_REQUIRED"
+  | "INVALID_URI"
+  | "INVALID_PARAMETER"
+  | "OPERATION_NOT_ALLOWED"
+  | "UNKNOWN";
+
+export class PlayerError extends SpotifyError {
+  readonly namespace = "Player" as const;
+  readonly code: PlayerErrorCode;
+
+  constructor(code: PlayerErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -1,0 +1,20 @@
+export type { PlayerErrorCode } from "./error";
+export { PlayerError } from "./error";
+
+// ---------------------------------------------------------------------------
+// Player namespace (stub — implemented in Phase 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Spotify Player namespace. Transport controls, queue management, and
+ * player-state subscriptions. Requires `AppRemote.connect()` to be resolved
+ * before any call.
+ *
+ * @example
+ * ```ts
+ * import { Player } from "@wwdrew/expo-spotify-sdk";
+ *
+ * await Player.play(SpotifyURI.from("spotify:track:4uLU6hMCjMI75M1A2tKUQC"));
+ * ```
+ */
+export const Player = {} as const;

--- a/src/uri/index.ts
+++ b/src/uri/index.ts
@@ -1,0 +1,84 @@
+/**
+ * The six Spotify resource types accepted by App Remote APIs.
+ */
+export type SpotifyResourceType =
+  | "track"
+  | "album"
+  | "playlist"
+  | "artist"
+  | "show"
+  | "episode";
+
+/**
+ * Branded string type for Spotify URIs (`spotify:<type>:<id>`).
+ *
+ * Construct via `SpotifyURI.from(str)` (validates) or
+ * `SpotifyURI.unsafe(str)` (skips validation — use only when the source is
+ * trusted, e.g. a URI that came back from the Spotify SDK itself).
+ */
+export type SpotifyURI = string & { readonly __brand: "SpotifyURI" };
+
+const URI_RE =
+  /^spotify:(track|album|playlist|artist|show|episode):([A-Za-z0-9]+)$/;
+
+/**
+ * Helpers for constructing, validating and decomposing {@link SpotifyURI}
+ * values.
+ *
+ * @example
+ * ```ts
+ * const uri = SpotifyURI.from("spotify:track:4uLU6hMCjMI75M1A2tKUQC");
+ * const { type, id } = SpotifyURI.parse(uri);
+ * const rebuilt = SpotifyURI.build("track", id);
+ * ```
+ */
+export const SpotifyURI = {
+  /**
+   * Cast `uri` to {@link SpotifyURI} after validation.
+   * Throws a plain `Error` if the URI does not match the `spotify:<type>:<id>`
+   * format — use at app-code call sites where you want early feedback.
+   */
+  from(uri: string): SpotifyURI {
+    if (!SpotifyURI.isValid(uri)) {
+      throw new Error(
+        `Invalid Spotify URI: "${uri}". Expected spotify:<type>:<id> where ` +
+          `<type> is one of: track, album, playlist, artist, show, episode.`,
+      );
+    }
+    return uri as SpotifyURI;
+  },
+
+  /**
+   * Cast `uri` to {@link SpotifyURI} without validation.
+   * Use only for URIs that originate from the Spotify SDK itself (i.e. already
+   * known-valid values coming back over the bridge).
+   */
+  unsafe(uri: string): SpotifyURI {
+    return uri as SpotifyURI;
+  },
+
+  /**
+   * Decompose a {@link SpotifyURI} into its `{ type, id }` parts.
+   */
+  parse(uri: SpotifyURI): { type: SpotifyResourceType; id: string } {
+    const m = uri.match(URI_RE);
+    if (!m) {
+      throw new Error(`Cannot parse Spotify URI: "${uri}"`);
+    }
+    return { type: m[1] as SpotifyResourceType, id: m[2] };
+  },
+
+  /**
+   * Build a {@link SpotifyURI} from a resource type and ID.
+   */
+  build(type: SpotifyResourceType, id: string): SpotifyURI {
+    return `spotify:${type}:${id}` as SpotifyURI;
+  },
+
+  /**
+   * Type-guard: returns `true` if `uri` is a valid Spotify URI string.
+   */
+  isValid(uri: string): uri is SpotifyURI {
+    return URI_RE.test(uri);
+  },
+} as const;

--- a/src/user/error.ts
+++ b/src/user/error.ts
@@ -1,0 +1,18 @@
+import { SpotifyError } from "../error";
+
+export type UserErrorCode =
+  | "NOT_CONNECTED"
+  | "CONNECTION_LOST"
+  | "INVALID_URI"
+  | "OPERATION_NOT_ALLOWED"
+  | "UNKNOWN";
+
+export class UserError extends SpotifyError {
+  readonly namespace = "User" as const;
+  readonly code: UserErrorCode;
+
+  constructor(code: UserErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+}

--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -1,0 +1,19 @@
+export type { UserErrorCode } from "./error";
+export { UserError } from "./error";
+
+// ---------------------------------------------------------------------------
+// User namespace (stub — implemented in Phase 4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Spotify User namespace. Capabilities and library state queries and
+ * mutations. Requires `AppRemote.connect()` to be resolved before any call.
+ *
+ * @example
+ * ```ts
+ * import { User } from "@wwdrew/expo-spotify-sdk";
+ *
+ * const caps = await User.getCapabilities();
+ * ```
+ */
+export const User = {} as const;


### PR DESCRIPTION
- Abstract SpotifyError base class in src/error.ts (carries `code` +
  `namespace`; never thrown directly)
- Six concrete error subclasses: AuthError, AppRemoteError, PlayerError,
  UserError, ContentError, ImagesError — each with a typed error-code union
- Branded SpotifyURI type (src/uri/) with from/unsafe/parse/build/isValid helpers
- Auth namespace (src/auth/): migrates authenticateAsync → Auth.authenticate,
  refreshSessionAsync → Auth.refresh, cancelPendingAuthAsync → Auth.cancelPending,
  addSessionChangeListener → Auth.addListener("sessionChange", ...)
- Empty stubs for AppRemote, Player, User, Content, Images namespaces
  (Phase 2–5 will fill them in)
- src/index.ts: exports all namespaces + deprecated v0.x top-level shims
  (isAvailable, authenticateAsync, refreshSessionAsync, cancelPendingAuthAsync,
  addSessionChangeListener, SpotifyConfig, SpotifyRefreshConfig, SpotifyErrorCode)
  so existing callers continue to compile — remove at v2.0.0
- Web stub updated: remove "planned" language; web is not supported
- CONTEXT.md: add branch naming convention (feat/*, fix/*, docs/* …)