### PR TITLE
docs: main = SDK 56 (2.x), v1 = SDK 55 (1.x)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,9 +6,18 @@ Reference for humans and agents. Use this file to keep terminology straight when
 
 This repo uses [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description` (e.g. `fix(ios): …`, `feat(android): …`, `docs: …`). Use an optional scope when the change is platform- or area-specific.
 
+## Branches
+
+| Branch | npm | Expo SDK | Use for |
+| --- | --- | --- | --- |
+| **`main`** | `2.x` | 56+ | Default: features, fixes, releases |
+| **`v1`** | `1.x` | 55 | Maintenance backports only |
+
+Topic branch names follow conventional-commit prefixes: `feat/*`, `fix/*`, `docs/*`, etc. Open PRs against **`main`** unless you are intentionally targeting the SDK 55 lane (then branch from **`v1`** and merge back to **`v1`**).
+
 ## Branch naming
 
-Branch names follow the same `type/` prefix as conventional commits: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`, `test/*`. Examples: `feat/auth-namespace`, `fix/android-token-flow`, `docs/v1-plan`.
+Branch names follow the same `type/` prefix as conventional commits: `feat/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`, `test/*`. Examples: `feat/auth-namespace`, `fix/android-token-flow`, `docs/release-v2`.
 
 ## Terminology
 
@@ -33,13 +42,21 @@ Branch names follow the same `type/` prefix as conventional commits: `feat/*`, `
 
 **Rule of thumb:** This library wraps the **Auth SDK** and (in v1) the **App Remote SDK**. Anything that lives at `api.spotify.com` is the consumer's responsibility — they have the access token, they call REST.
 
-## v1.0.0 direction
+## Release lanes
 
-`v1.0.0` adds App Remote support (transport, now-playing, hooks) on top of the existing Auth surface. It targets Expo SDK 55 (iOS 15.1+). See [ADR-0005](./docs/adr/0005-sdk-lane-versioning.md) for the lane versioning strategy.
+Both lanes ship the full Auth + App Remote API ([ADR-0006](./docs/adr/0006-namespaced-api-and-app-remote-scope.md)). The major version selects the **Expo SDK runtime**, not a different feature set ([ADR-0005](./docs/adr/0005-sdk-lane-versioning.md)).
 
-## v2.0.0 direction (SDK 56 lane only)
+### `1.x` on `v1` (Expo SDK 55)
 
-`v2.0.0` is the Expo SDK 56+ line (`main` after Phase 7 in [V1_PLAN.md](./docs/V1_PLAN.md)). Besides the SDK / iOS floor bump, it ships **typed config plugins**: import from `@wwdrew/expo-spotify-sdk/plugin` in `app.config.ts` for autocomplete and type-checked `SpotifyConfig` options (Expo SDK 56 feature). The legacy string/tuple plugin entry (`["@wwdrew/expo-spotify-sdk", { … }]`) remains supported on v2; typed imports are **not** backported to the `v1` / SDK 55 branch.
+- npm **`1.x`**, branch **`v1`**, iOS 15.1+, `expo-modules-core@^3.x`
+- **`1.0.0`** is published; install with `npm install @wwdrew/expo-spotify-sdk@1` (or pin `1.x.y`)
+- Config plugin: string/tuple form in `app.json` / `app.config.ts` only
+
+### `2.x` on `main` (Expo SDK 56+)
+
+- npm **`2.x`**, branch **`main`**, iOS 16.4+, `expo-modules-core@^56`
+- Active development; **`2.0.0`** pending Release Please merge
+- **Typed config plugin** on `main` only: `import { withSpotifySdk } from "@wwdrew/expo-spotify-sdk/plugin"` in `app.config.ts`. Legacy string/tuple plugin syntax remains supported.
 
 **Explicitly not in v1 (or any version):**
 
@@ -50,5 +67,5 @@ Branch names follow the same `type/` prefix as conventional commits: `feat/*`, `
 
 ## Related docs
 
-- [README.md](./README.md) — install, v1 namespaced API (Auth + App Remote), and migration from v0.x.
+- [README.md](./README.md) — install, SDK lane table, public API (Auth + App Remote), migration from v0.x.
 - [docs/adr/](./docs/adr/) — architecture decision records.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,24 @@ you need to get a PR merged.
 
 ---
 
+## Which branch?
+
+| You are… | Branch | Expo SDK |
+| --- | --- | --- |
+| Adding features or fixing bugs for current consumers | **`main`** | 56+ (`2.x`) |
+| Backporting a fix for SDK 55 users | **`v1`** | 55 (`1.x`) |
+
+PRs should target **`main`** by default. The **`v1`** branch is frozen at the SDK 55 toolchain — do not merge `main` into `v1`.
+
 ## Development setup
+
+Work on **`main`** unless you are explicitly maintaining the SDK 55 lane:
 
 ```sh
 # 1. Fork and clone
 git clone https://github.com/<you>/expo-spotify-sdk.git
 cd expo-spotify-sdk
+git checkout main
 
 # 2. Install dependencies (Yarn v1 — matches CI)
 yarn install
@@ -123,10 +135,7 @@ When adding new plugin modifiers, add a corresponding test that checks:
 
 ## Release process
 
-Releases are automated via [Release Please](https://github.com/googleapis/release-please).
-Merging a commit that triggers a release will open or update a release PR.
-When that PR is merged, the workflow publishes to npm automatically — no
-manual `npm publish` required.
+- **`2.x` from `main`** — [Release Please](https://github.com/googleapis/release-please) opens a release PR; merging it publishes to npm (see [docs/RELEASE.md](docs/RELEASE.md)).
+- **`1.x` from `v1`** — maintenance releases from the `v1` branch (see [docs/RELEASE.md](docs/RELEASE.md)).
 
-Maintainers don't need to do anything special beyond merging commits with
-well-formed Conventional Commit messages.
+Use Conventional Commits on the branch you are releasing from.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Both lanes ship the same public API (Auth + App Remote namespaces and hooks). Th
 
 The current `main` branch targets **Expo SDK 56** and releases as **`2.x`**. For Expo SDK 55, install **`1.x`** from the `v1` branch ([ADR-0005](./docs/adr/0005-sdk-lane-versioning.md)).
 
-## v1 namespaced API
+## Public API (Auth + App Remote)
 
 ```ts
 import {
@@ -63,8 +63,10 @@ Top-level v0-style functions (`authenticateAsync`, `isAvailable`, etc.) are stil
 ## Quick start (Expo)
 
 ```sh
-# 1. Install
+# 1. Install (Expo SDK 56+ — matches `main` / npm `2.x`)
 npx expo install @wwdrew/expo-spotify-sdk
+
+# Expo SDK 55 only: npx expo install @wwdrew/expo-spotify-sdk@1
 
 # 2. Add the config plugin to app.config.ts / app.json  (see Configuration below)
 # 3. Regenerate native projects
@@ -326,7 +328,7 @@ For iOS, if `connect()` fails with `CONNECTION_FAILED`, foreground the Spotify a
 
 ## Migration from v0.x
 
-v0.x top-level functions remain exported but are deprecated (removed in v2.0.0).
+v0.x top-level functions remain exported but are deprecated (scheduled for removal in a future major).
 
 | v0.x | v1 |
 | --- | --- |
@@ -696,8 +698,8 @@ App Remote player state is limited for non-Premium users. Check `GET /v1/me` →
 
 - [CONTEXT.md](./CONTEXT.md) — terminology (Auth SDK vs App Remote vs Web API)
 - [docs/V1_PLAN.md](./docs/V1_PLAN.md) — implementation plan and release criteria
-- [docs/QA_CHECKLIST.md](./docs/QA_CHECKLIST.md) — manual QA sign-off before `v1.0.0`
-- [docs/RELEASE.md](./docs/RELEASE.md) — tag `v1.0.0` and cut the `v1` branch
+- [docs/QA_CHECKLIST.md](./docs/QA_CHECKLIST.md) — manual QA before a `2.x` release on `main` (or `1.x` on `v1`)
+- [docs/RELEASE.md](./docs/RELEASE.md) — Release Please on `main` (`2.x`); maintenance releases from `v1` (`1.x`)
 - [ATTRIBUTION.md](./ATTRIBUTION.md) — third-party SDKs and scope boundaries
 
 ## Acknowledgements

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -1,10 +1,33 @@
-# Manual QA checklist — v1.0.0 (Expo SDK 55 lane)
+# Manual QA checklist
 
-Run on **real devices** before tagging `v1.0.0`. Sign off each row for iOS and Android.
+Run on **real devices** before a release. Use the checklist that matches your **branch and Expo SDK**, not both for every release.
 
-**Accounts:** at least one **Premium** and one **Free** tester (added under Spotify Dashboard → User Management for Development Mode apps).
+| Release | Branch | Expo SDK | When to use |
+| --- | --- | --- | --- |
+| **`2.x`** | `main` | 56+ | Before merging a Release Please PR on `main` |
+| **`1.x`** | `v1` | 55 | Before publishing a maintenance release from `v1` |
+
+**Accounts:** at least one **Premium** and one **Free** tester (Spotify Dashboard → User Management for Development Mode apps).
 
 **Environment:** Spotify app installed and logged in; for token-swap flows, Expo dev server serving `/swap` and `/refresh` (see [README](../README.md#token-swap-server)).
+
+**Setup:**
+
+```sh
+# SDK 56 (2.x) — default
+git checkout main && yarn install
+cd example && yarn install && cd ..
+npx expo prebuild   # if native projects changed
+
+# SDK 55 (1.x) — maintenance lane only
+git checkout v1 && yarn install
+cd example && yarn install && cd ..
+npx expo prebuild
+```
+
+On **`main`**, you can also exercise the **typed config plugin** in `app.config.ts` (`import { withSpotifySdk } from "@wwdrew/expo-spotify-sdk/plugin"`). That path is not on `v1`.
+
+---
 
 ## Auth
 
@@ -65,10 +88,11 @@ Run on **real devices** before tagging `v1.0.0`. Sign off each row for iOS and A
 | E1 | Full flow: connect → App Remote → now playing → browse | ☐ | ☐ |
 | E2 | Account tier label matches `/v1/me` `product` | ☐ | ☐ |
 | E3 | Errors show `[namespace] code: message` in UI | ☐ | ☐ |
+| E4 | **`main` only:** `withSpotifySdk` in `app.config.ts` prebuilds without errors | ☐ | ☐ |
 
 ## Sign-off
 
-| Role | Name | Date |
-| --- | --- | --- |
-| Tester | | |
-| Maintainer | | |
+| Release | Branch | Tester | Date |
+| --- | --- | --- | --- |
+| `2.x` | `main` | | |
+| `1.x` | `v1` | | |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,41 +1,82 @@
-# Releasing v1.0.0 (Expo SDK 55 lane)
+# Release process
 
-Follow after [QA_CHECKLIST.md](./QA_CHECKLIST.md) is signed off on `main` (SDK 55 toolchain).
+Two long-lived branches, two npm majors. See [ADR-0005](./adr/0005-sdk-lane-versioning.md).
 
-## 1. Pre-release
+| Branch | npm major | Expo SDK | iOS min | Status |
+| --- | --- | --- | --- | --- |
+| **`main`** | `2.x` | 56+ | 16.4 | Active development; default for new work |
+| **`v1`** | `1.x` | 55 | 15.1 | Maintenance; bugfixes and security backports |
 
-- [ ] `yarn typecheck` and `yarn lint` pass
-- [ ] `yarn build` produces `build/` and `yarn build:plugin` produces `plugin/build/`
-- [ ] README, CHANGELOG, and coverage matrix in [V1_PLAN.md](./V1_PLAN.md) are current
-- [ ] `package.json` version is `1.0.0`
+---
 
-## 2. Tag on `main`
+## Releasing `2.x` from `main` (Expo SDK 56)
+
+Default path for new features and fixes on the SDK 56 lane.
+
+### Pre-release
+
+Follow [QA_CHECKLIST.md](./QA_CHECKLIST.md) on the **SDK 56** toolchain (`main` checkout, `example/` on SDK 56).
+
+- [ ] `yarn typecheck` and `yarn lint` pass on `main`
+- [ ] `yarn build` → `build/` and `yarn build:plugin` → `plugin/build/`
+- [ ] README and CHANGELOG on `main` reflect the SDK 56 / `2.x` lane
+
+### Publish
+
+Releases are automated via [Release Please](https://github.com/googleapis/release-please) on **`main`**:
+
+1. Merge conventional commits to `main`.
+2. Release Please opens/updates a release PR (e.g. `chore(main): release expo-spotify-sdk 2.0.0`).
+3. Merge that PR → GitHub Release + **npm publish** (`.github/workflows/release.yml` runs `yarn prepublishOnly` then `npm publish`).
+
+No manual `npm publish` unless automation is broken.
+
+### Post-release
+
+- [ ] GitHub Release notes mention **Expo SDK 56** and link to [ADR-0005](./adr/0005-sdk-lane-versioning.md)
+- [ ] npm `latest` points at the new `2.x` (verify on https://www.npmjs.com/package/@wwdrew/expo-spotify-sdk)
+
+---
+
+## Releasing `1.x` from `v1` (Expo SDK 55)
+
+For consumers who cannot move to Expo SDK 56 yet.
+
+### Branch
+
+`v1` is pinned at the **`expo-spotify-sdk-v1.0.0`** tag (`d144507`) — the last commit before SDK 56 landed on `main`. Do **not** cut `v1` from current `main`.
 
 ```sh
-git checkout main
-git pull
-git tag -a v1.0.0 -m "v1.0.0 — Expo SDK 55 lane: Auth + App Remote namespaces"
-git push origin v1.0.0
+git fetch origin
+git checkout v1
+git pull origin v1
 ```
 
-Release to npm via your existing automation (e.g. GitHub Release + release-please) or:
+### Pre-release
 
-```sh
-npm publish --access public
-```
+Follow [QA_CHECKLIST.md](./QA_CHECKLIST.md) on the **SDK 55** toolchain (`v1` checkout; example app on SDK 55).
 
-## 3. Cut the `v1` maintenance branch
+- [ ] `yarn` / build / test pass on `v1` (see `package.json` scripts on that branch)
+- [ ] Changes are backported intentionally — `main` is not merged wholesale into `v1`
 
-Immediately after the tag:
+### Publish
 
-```sh
-git branch v1 v1.0.0
-git push -u origin v1
-```
+Configure Release Please (or your process) so **`1.x.y` releases run from `v1`**, not `main`. Until that is wired, maintainers can publish manually from `v1` after a version bump.
 
-Configure **release-please** (or equivalent) so **`v1.x.y` releases publish from `v1`**, not `main`. `main` will later become the SDK 56 / `2.x` line ([Phase 7](./V1_PLAN.md#phase-7--migrate-main-to-expo-sdk-56-v200)).
+`1.0.0` is already on npm from the initial SDK 55 release (tag `expo-spotify-sdk-v1.0.0`).
 
-## 4. Post-release
+### Post-release
 
-- [ ] GitHub Release notes mention **Expo SDK 55** and link to [ADR-0005](./adr/0005-sdk-lane-versioning.md)
-- [ ] Example app README / npm keywords mention `v1.x` for SDK 55 consumers
+- [ ] GitHub Release notes mention **Expo SDK 55**
+- [ ] README on `v1` (if branched docs differ) still directs SDK 56 consumers to `2.x` on `main`
+
+---
+
+## Porting fixes between lanes
+
+| Direction | Guidance |
+| --- | --- |
+| `main` → `v1` | Cherry-pick only when the fix applies to SDK 55 / does not depend on SDK 56 APIs (e.g. typed config plugin). |
+| `v1` → `main` | Cherry-pick when the bug exists on both lanes. |
+
+Feature work lands on **`main` first**; backport to `v1` at maintainer discretion.

--- a/docs/V1_PLAN.md
+++ b/docs/V1_PLAN.md
@@ -2,7 +2,7 @@
 
 Plan for getting `@wwdrew/expo-spotify-sdk` from its current auth-only `0.8.x` state to a feature-complete native-SDK wrapper covering both halves of Spotify's mobile SDKs: the **Auth SDK** (today) and the **App Remote SDK** (new).
 
-**Status:** Phase 7 in progress on `main` (SDK 56 → `2.0.0`). Phase 6 complete; `v1.0.0` shipped on the `v1` branch (SDK 55). Source of truth for per-method status: the [Coverage matrix](#5-coverage-matrix). Remaining: manual QA on SDK 56, tag `v2.0.0` — see [RELEASE.md](./RELEASE.md) (update for v2 when ready).
+**Status:** **`main` = Expo SDK 56 / `2.x`** (Phase 7 complete in tree; pending npm `2.0.0` via Release Please). **`v1` branch = SDK 55 / `1.x`** (`1.0.0` on npm). Source of truth for per-method status: the [Coverage matrix](#5-coverage-matrix). Remaining before `2.0.0` ship: SDK 56 manual QA — [QA_CHECKLIST.md](./QA_CHECKLIST.md), then merge Release Please PR — [RELEASE.md](./RELEASE.md).
 
 **Related:** [CONTEXT.md](../CONTEXT.md) (terminology), [ADR-0004](./adr/0004-no-web-api-wrapper.md), [ADR-0005](./adr/0005-sdk-lane-versioning.md), [ADR-0006](./adr/0006-namespaced-api-and-app-remote-scope.md).
 
@@ -27,7 +27,7 @@ Plan for getting `@wwdrew/expo-spotify-sdk` from its current auth-only `0.8.x` s
 
 ## 2. What exists today (baseline)
 
-**Current release (pending tag):** `2.0.0` on `main` (Expo SDK 56). `1.x` is maintained on the `v1` branch (SDK 55).
+**Branches:** `main` → **`2.x`** (Expo SDK 56+, active development). `v1` → **`1.x`** (Expo SDK 55, maintenance). **`2.0.0`** on `main` is pending npm publish; **`1.0.0`** is live from `v1`.
 
 | Domain | Public API | iOS | Android |
 | --- | --- | --- | --- |
@@ -273,7 +273,7 @@ Legend: ✅ shipped · 🟡 in progress · ⬜ not started · ➖ N/A on this pl
 
 Ordered for vertical slices (each phase produces something demoable on device) and dependency order (foundation → connection → player → polish → branch cut → SDK 56 migration).
 
-**Development sequence:** All App Remote work (Phases 1–6) happens on `main` while `main` is still on Expo SDK 55 — the same toolchain `0.8.x` ships on today. Only after v1.0.0 is feature-complete and tagged on `main` do we cut the `v1` branch (as the long-lived SDK 55 lane) and then migrate `main` itself to SDK 56 in Phase 7 to become the v2.0.0 line. This avoids doing the App Remote work twice (once per SDK lane); the SDK 56 migration is then a focused, isolated change on top of a known-good v1.0.0.
+**Development sequence (completed):** Phases 1–6 landed on `main` while it still targeted SDK 55. `1.0.0` was tagged (`expo-spotify-sdk-v1.0.0`), then the **`v1` branch** was cut from that tag. **`main`** was migrated to SDK 56 in Phase 7 and now ships **`2.x`**. New feature work targets **`main`**; backports go to **`v1`** when needed ([ADR-0005](./adr/0005-sdk-lane-versioning.md)).
 
 ### Phase 0 — Repo & doc setup (no branch cuts, no SDK bumps yet)
 
@@ -356,10 +356,10 @@ Ordered for vertical slices (each phase produces something demoable on device) a
 | Example app polish | Save button gated by capabilities, structured error UI, a11y labels | ✅ |
 | Cross-platform parity audit | Documented in README § Platform differences | ✅ |
 | Manual QA on real devices | [QA_CHECKLIST.md](./QA_CHECKLIST.md) | ✅ maintainer |
-| Tag `v1.0.0` on `main` | [RELEASE.md](./RELEASE.md) | ✅ maintainer |
-| Cut `v1` branch from tag | `release-please` → `v1.x.y` from `v1` | ✅ maintainer |
+| Tag `v1.0.0` (`expo-spotify-sdk-v1.0.0`) | [RELEASE.md](./RELEASE.md) | ✅ |
+| Cut `v1` branch from tag | `origin/v1` at `d144507` | ✅ |
 
-**Exit:** `v1.0.0` is shipped on npm, the `v1` branch exists and is set up for `v1.x.y` releases. `main` is now free to migrate to SDK 56 in Phase 7.
+**Exit:** `v1.0.0` is on npm; `v1` is the SDK 55 lane. `main` proceeded to Phase 7.
 
 ### Phase 7 — Migrate `main` to Expo SDK 56 (v2.0.0)
 
@@ -373,10 +373,10 @@ Ordered for vertical slices (each phase produces something demoable on device) a
 | **Typed config plugin** (`@wwdrew/expo-spotify-sdk/plugin`) | Typed tuple helper + string/tuple backward compat | ✅ |
 | Update README on `main` to say "v2.x for SDK 56+; see v1.x for SDK 55" | Lane → version mapping | ✅ |
 | Bump `package.json` version → `2.0.0` | | ✅ |
-| Run full QA pass on SDK 56 toolchain | Same checklist as Phase 6, this time on SDK 56 | ⬜ maintainer |
-| Tag `v2.0.0` on `main` | Release on the SDK 56 toolchain | ⬜ maintainer |
+| Run full QA pass on SDK 56 toolchain | [QA_CHECKLIST.md](./QA_CHECKLIST.md) on `main` | ⬜ maintainer |
+| Ship `v2.0.0` on `main` | Merge Release Please PR → npm ([RELEASE.md](./RELEASE.md)) | ⬜ maintainer |
 
-**Exit:** `v2.0.0` is shipped on npm. Both lanes are now live: `v1.x` (on `v1` branch, SDK 55) and `v2.x` (on `main`, SDK 56+). Future feature work happens on `main` first; backporting to `v1` is at the maintainer's discretion per [ADR-0005](./adr/0005-sdk-lane-versioning.md).
+**Exit:** `v2.0.0` is on npm. Both lanes live: **`v1`** (`1.x`, SDK 55) and **`main`** (`2.x`, SDK 56+). Feature work on **`main`**; backports to **`v1`** at maintainer discretion ([ADR-0005](./adr/0005-sdk-lane-versioning.md)).
 
 ---
 
@@ -469,8 +469,9 @@ All required before tagging either major:
 - [x] README rewritten with new API + migration table + auto-connect recipe.
 - [x] Every error code has documented "when" and "what to do" in the README.
 - [x] [ATTRIBUTION.md](../ATTRIBUTION.md) reflects no Web API wrapping intent.
-- [ ] Manual QA on real devices, Premium and Free accounts ([checklist](./QA_CHECKLIST.md)).
-- [ ] Tag `v1.0.0` and cut `v1` branch ([release steps](./RELEASE.md)).
+- [x] `v1.0.0` on npm; `v1` branch cut from `expo-spotify-sdk-v1.0.0` ([RELEASE.md](./RELEASE.md)).
+- [ ] SDK 56 manual QA on `main` before shipping `2.0.0` ([checklist](./QA_CHECKLIST.md)).
+- [ ] `2.0.0` published from `main` via Release Please ([RELEASE.md](./RELEASE.md)).
 
 **Semver after v1 / v2:**
 

--- a/docs/adr/0005-sdk-lane-versioning.md
+++ b/docs/adr/0005-sdk-lane-versioning.md
@@ -61,21 +61,18 @@ The deprecation date for `v1.x.x` is **not set**. The maintainer reviews periodi
 
 ## Implementation
 
-The branch cut and SDK 56 migration happen **after** all v1.0.0 feature work is complete on `main` (still on SDK 55) — see [V1_PLAN.md §6 Phases 6–7](../V1_PLAN.md#6-implementation-phases). This avoids doing the App Remote work twice.
+Completed per [V1_PLAN.md §6 Phases 6–7](../V1_PLAN.md#6-implementation-phases).
 
-| Step | Where | When |
+| Step | Where | Status |
 | --- | --- | --- |
-| Develop App Remote + namespacing on `main` while it is still on Expo SDK 55 | `main` | Phases 1–6 |
-| Tag `v1.0.0` on `main` | `main` | End of Phase 6 |
-| Cut `v1` branch from the `v1.0.0` tag | git, branch `v1` | Immediately after tag |
-| `release-please-config.json` on `v1` configured to release `v1.x.y` from `v1` branch | `v1` | Immediately after branch cut |
-| Bump `main` to SDK 56: `ios/ExpoSpotifySDK.podspec` → `:ios, '16.4'`; `package.json` dev deps → `^56`; `example/` pinned to SDK 56 | `main` | Phase 7 |
-| Bump `package.json` version on `main` to `2.0.0` | `main` | Phase 7 |
-| Export typed config plugin at `@wwdrew/expo-spotify-sdk/plugin` (SDK 56 pattern) | `main` only | Phase 7 — not on `v1` |
-| README on both branches documents the lane → version mapping prominently | both | Phases 6 (main / v1) and 7 (main) |
-| CHANGELOG entries reference the lane (`v1.0.0 — Expo SDK 55 lane`, `v2.0.0 — Expo SDK 56 lane`) | both | At release |
-| GitHub Actions runs per branch with the appropriate Xcode / Android SDK matrix | `.github/workflows/` per branch | Phase 7 (main migration); pre-existing on `v1` |
-| Tag `v2.0.0` on `main` | `main` | End of Phase 7 |
+| App Remote + namespaced API (Phases 1–6) | `main` (then SDK 55) | ✅ |
+| Tag `expo-spotify-sdk-v1.0.0`, publish **`1.0.0`** | npm + git tag | ✅ |
+| Cut **`v1`** from that tag (`d144507`) | `origin/v1` | ✅ |
+| Migrate **`main`** to SDK 56; `package.json` → `2.0.0` | `main` | ✅ |
+| Typed config plugin `@wwdrew/expo-spotify-sdk/plugin` | `main` only | ✅ |
+| README lane table (`1.x` / `v1`, `2.x` / `main`) | `main` | ✅ |
+| Publish **`2.0.0`** via Release Please on `main` | npm | ⬜ pending |
+| Release Please for **`1.x.y`** from `v1` | `v1` | ⬜ optional follow-up |
 
 ## Validation
 

--- a/docs/adr/0006-namespaced-api-and-app-remote-scope.md
+++ b/docs/adr/0006-namespaced-api-and-app-remote-scope.md
@@ -116,7 +116,7 @@ The phased plan (Phase 0 → Phase 6) lives in [V1_PLAN.md §6](../V1_PLAN.md#6-
 | 5 | `Content` + `Images`. |
 | 6 | Hardening, README rewrite, example app polish. |
 
-Each phase lands on both `main` (v2 / SDK 56) and `v1` (SDK 55) per [ADR-0005](./0005-sdk-lane-versioning.md).
+Phases 1–6 landed before the SDK 56 migration; the same API ships on **`v1`** (SDK 55) and **`main`** (SDK 56) per [ADR-0005](./0005-sdk-lane-versioning.md). New API work targets **`main`** first.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Document the two-branch release model: **`main`** → Expo SDK 56 / npm **`2.x`**, **`v1`** → SDK 55 / npm **`1.x`** (cut from `expo-spotify-sdk-v1.0.0`).
- Rewrite [docs/RELEASE.md](docs/RELEASE.md) and [docs/QA_CHECKLIST.md](docs/QA_CHECKLIST.md) for both lanes.
- Update [CONTRIBUTING.md](CONTRIBUTING.md), [CONTEXT.md](CONTEXT.md), [docs/V1_PLAN.md](docs/V1_PLAN.md), and ADRs 0005/0006.
- README: SDK 56 default install, public API section title, related-doc links.

## Test plan

- [x] Docs only — no code changes
- [ ] Review links and branch names read correctly on GitHub


Made with [Cursor](https://cursor.com)