### PR TITLE
feat(app-remote): add AppRemote.authorizeAndPlay to wake a suspended Spotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,20 @@ export function useAutoConnectAppRemote(options?: { once?: boolean }) {
 }
 ```
 
-For iOS, if `connect()` fails with `CONNECTION_FAILED`, foreground the Spotify app and retry manually — see [Troubleshooting](#troubleshooting).
+For iOS, if `connect()` fails with `CONNECTION_FAILED`, the Spotify app has likely been suspended in the background — `connect()` can only attach to an already-running Spotify. Instead of asking the user to foreground Spotify and retry manually, call `AppRemote.authorizeAndPlay(accessToken, uri?)`, which wakes Spotify (launching it if needed), starts playback, and then connects:
+
+```ts
+try {
+  await AppRemote.connect(session.accessToken);
+} catch (e) {
+  if (e instanceof AppRemoteError && e.code === "CONNECTION_FAILED") {
+    // Spotify was suspended — wake it, start playing, and connect.
+    await AppRemote.authorizeAndPlay(session.accessToken);
+  }
+}
+```
+
+Note that `authorizeAndPlay()` always starts (or resumes) playback and briefly switches to the Spotify app — see [Troubleshooting](#troubleshooting).
 
 ## Spotify Premium and App Remote
 
@@ -400,7 +413,7 @@ On iOS this can also be a stuck state when Spotify never redirects back. Call `A
 **App Remote: `CONNECTION_FAILED` / `Connection refused` (iOS code 61)**
 The Spotify app is installed but its App Remote transport is not accepting connections. Common causes:
 
-1. **Spotify is not in the foreground** — switch to Spotify, then retry `AppRemote.connect()`.
+1. **Spotify is suspended / not in the foreground** — `connect()` only attaches to a running Spotify. Call `AppRemote.authorizeAndPlay(accessToken, uri?)` to wake it (it launches Spotify, starts playback, and connects), or have the user switch to Spotify and retry `AppRemote.connect()`.
 2. **Connect ran before auth finished** — call `AppRemote.connect()` only after `Auth.authenticate()` resolves.
 3. **Stale access token** — refresh or re-authenticate, then reconnect.
 4. **Retry loop on startup** — avoid calling `connect()` on every render while `connectionState === "disconnected"`; gate on a one-shot flag or user action.

--- a/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
@@ -202,6 +202,17 @@ class ExpoSpotifySDKModule : Module() {
       )
     }
 
+    AsyncFunction("appRemoteAuthorizeAndPlay") Coroutine { accessToken: String, uri: String ->
+      val manifest = readManifestConfig()
+      appRemoteCoordinator.authorizeAndPlay(
+        context = context,
+        clientId = manifest.clientId,
+        redirectUri = manifest.redirectUri,
+        accessToken = accessToken,
+        uri = uri,
+      )
+    }
+
     AsyncFunction("appRemoteDisconnect") Coroutine { ->
       appRemoteCoordinator.disconnect()
     }

--- a/android/src/main/java/expo/modules/spotifysdk/SpotifyAppRemoteCoordinator.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/SpotifyAppRemoteCoordinator.kt
@@ -132,6 +132,38 @@ class SpotifyAppRemoteCoordinator {
   }
 
   /**
+   * Wakes the Spotify app and starts playback, then ensures an active App
+   * Remote connection — the cross-platform counterpart of iOS
+   * `authorizeAndPlayURI`.
+   *
+   * On Android there is no dedicated "authorize and play" entry point:
+   * [SpotifyAppRemote.connect] already launches/wakes the Spotify service when
+   * it is installed, so this simply connects (if not already connected) and
+   * then issues a play (or resume, for an empty [uri]) command. The resulting
+   * playback keeps Spotify alive, mirroring the iOS behaviour.
+   *
+   * @param uri Spotify URI to play, or empty to resume the last/contextual track.
+   */
+  suspend fun authorizeAndPlay(
+    context: Context,
+    clientId: String,
+    redirectUri: String,
+    accessToken: String,
+    uri: String,
+  ) {
+    if (appRemote?.isConnected != true) {
+      connect(context, clientId, redirectUri, accessToken)
+    }
+    if (uri.isEmpty()) {
+      requireConnected("AppRemote.authorizeAndPlay").playerApi.resume()
+        .awaitVoid("AppRemote.authorizeAndPlay")
+    } else {
+      requireConnected("AppRemote.authorizeAndPlay").playerApi.play(uri)
+        .awaitVoid("AppRemote.authorizeAndPlay")
+    }
+  }
+
+  /**
    * Disconnects from the Spotify app. Safe to call when already disconnected.
    */
   fun disconnect() {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -93,7 +93,8 @@ Connects to the **running** Spotify app. All `Player`, `User`, `Content`, and `I
 
 | Method | Description |
 | --- | --- |
-| `connect(accessToken)` | Open IPC to Spotify. Resolves when connected. |
+| `connect(accessToken)` | Open IPC to Spotify. Resolves when connected. Requires Spotify to be **already running**. |
+| `authorizeAndPlay(accessToken, uri?)` | Wake Spotify (launch if suspended), start playback of `uri` (empty = resume last/random), then connect. |
 | `disconnect()` | Tear down connection. |
 | `isConnected()` | Synchronous snapshot. |
 | `getConnectionState()` | `"disconnected"` \| `"connecting"` \| `"connected"`. |
@@ -106,6 +107,8 @@ Connects to the **running** Spotify app. All `Player`, `User`, `Content`, and `I
 - **Android:** `accessToken` is accepted for API parity; the SDK uses the session cached in the Spotify app from your prior `Auth.authenticate()` call.
 
 Calling `connect()` while already connected is a no-op.
+
+**`authorizeAndPlay(accessToken, uri?)`** — use this to (re)connect when Spotify may not be running. Unlike `connect()`, which only attaches to an already-running Spotify, this performs an app-switch to Spotify (iOS `authorizeAndPlayURI`; Android wakes the App Remote service then issues a play command), reviving it. It **always starts or resumes playback** and briefly foregrounds Spotify — it cannot wake Spotify silently. On-demand playback of a specific `uri` requires Premium. Pass an empty `uri` (default) to resume the user's last/contextual track.
 
 ### `Player`
 

--- a/ios/ExpoSpotifyAppDelegate.swift
+++ b/ios/ExpoSpotifyAppDelegate.swift
@@ -1,7 +1,7 @@
 import ExpoModulesCore
 import SpotifyiOS
 
-/// Delivers Spotify auth redirect URLs received via the legacy
+/// Delivers Spotify redirect URLs received via the legacy
 /// `application(_:open:url:)` AppDelegate path.
 public class ExpoSpotifyAppDelegate: ExpoAppDelegateSubscriber {
   public func application(
@@ -9,6 +9,13 @@ public class ExpoSpotifyAppDelegate: ExpoAppDelegateSubscriber {
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
+    // Both the auth flow (SPTSessionManager) and App Remote's
+    // `authorizeAndPlay()` redirect through the same URL scheme. Offer the URL
+    // to the App Remote coordinator first — it only claims the redirect when an
+    // `authorizeAndPlay()` flow is actually pending — then fall back to auth.
+    if SpotifyAppRemoteCoordinator.shared?.handleAuthorizeRedirect(url) == true {
+      return true
+    }
     return SpotifyAuthCoordinator.shared?.handleOpenURL(url, options: options) ?? false
   }
 }

--- a/ios/ExpoSpotifySDKModule.swift
+++ b/ios/ExpoSpotifySDKModule.swift
@@ -138,6 +138,21 @@ public class ExpoSpotifySDKModule: Module {
       }
     }
 
+    AsyncFunction("appRemoteAuthorizeAndPlay") { (accessToken: String, uri: String) async throws -> Void in
+      guard let coordinator = SpotifyAppRemoteCoordinator.shared else {
+        throw AppRemoteException(AppRemoteError.connectionFailed(
+          "Missing `ExpoSpotifySDK` configuration in Info.plist."
+        ))
+      }
+      do {
+        try await coordinator.authorizeAndPlay(uri: uri, accessToken: accessToken)
+      } catch let error as AppRemoteError {
+        throw AppRemoteException(error)
+      } catch let error as NativePlayerError {
+        throw PlayerException(error)
+      }
+    }
+
     AsyncFunction("appRemoteDisconnect") { () async -> Void in
       await SpotifyAppRemoteCoordinator.shared?.disconnect()
     }

--- a/ios/SpotifyAppRemoteCoordinator.swift
+++ b/ios/SpotifyAppRemoteCoordinator.swift
@@ -25,6 +25,14 @@ actor SpotifyAppRemoteCoordinator {
   private var appRemote: SPTAppRemote?
   private var connectContinuation: CheckedContinuation<Void, Error>?
 
+  /// The `SPTAppRemote` awaiting an `authorizeAndPlay()` redirect, exposed
+  /// synchronously to the URL-redirect path. Mirrors the auth coordinator's
+  /// `nonisolated(unsafe)` `sessionManager`: it is only written from the
+  /// actor's executor (or the main-thread redirect handler) and read on the
+  /// main thread, so occasional cross-actor access is acceptable. `nil`
+  /// whenever no authorize-and-play flow is in flight.
+  nonisolated(unsafe) private var pendingAuthorizeRemote: SPTAppRemote?
+
   nonisolated(unsafe) private(set) var connectionStateString: String = "disconnected"
 
   var onConnectionStateChange: ((String) -> Void)?
@@ -97,6 +105,102 @@ actor SpotifyAppRemoteCoordinator {
     }
   }
 
+  /// Wakes the Spotify app (via `authorizeAndPlayURI`), starts playback, and
+  /// then completes the App Remote connection once Spotify redirects back.
+  ///
+  /// Unlike `connect()`, this works even when the Spotify app has been
+  /// suspended: `authorizeAndPlayURI` performs an app-switch to Spotify, which
+  /// revives it. Spotify then redirects back to the host app with an access
+  /// token; `handleAuthorizeRedirect(_:)` consumes that redirect and calls
+  /// `connect()` on the same `SPTAppRemote` instance.
+  ///
+  /// The `connectContinuation` is reused for the whole flow, so `didConnect()`
+  /// / `didFailToConnect(error:)` resolve it exactly as for `connect()`.
+  func authorizeAndPlay(uri: String, accessToken: String) async throws {
+    if appRemote?.isConnected == true {
+      // Already connected — honour the request by (re)starting playback.
+      if uri.isEmpty {
+        try await playerResume()
+      } else {
+        try await playerPlay(uri: uri)
+      }
+      return
+    }
+    guard connectContinuation == nil else {
+      throw AppRemoteError.connectionFailed("A connection attempt is already in progress")
+    }
+
+    transitionState("connecting")
+
+    let params = SPTAppRemoteConnectionParams(
+      accessToken: accessToken,
+      defaultImageSize: CGSize.zero,
+      imageFormat: .any
+    )
+    let remote = SPTAppRemote(
+      configuration: sptConfiguration,
+      connectionParameters: params,
+      logLevel: .error
+    )
+    remote.delegate = connectionBridge
+    appRemote = remote
+    pendingAuthorizeRemote = remote
+
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+      self.connectContinuation = cont
+      Task { @MainActor in
+        // `authorizeAndPlayURI` returns false synchronously when the Spotify
+        // app is not installed — no redirect will ever arrive, so fail now.
+        let launched = remote.authorizeAndPlayURI(uri)
+        if !launched {
+          Task {
+            await self.didFailToConnect(error: NSError(
+              domain: "ExpoSpotifySDK",
+              code: -1,
+              userInfo: [NSLocalizedDescriptionKey: "authorizeAndPlay: the Spotify app is not installed"]
+            ))
+          }
+        }
+      }
+    }
+  }
+
+  /// Consumes a redirect URL produced by an `authorizeAndPlay()` app-switch.
+  /// Returns `true` if an authorize flow was pending and the URL was handled
+  /// (so the AppDelegate should not also forward it to the auth coordinator).
+  ///
+  /// Synchronous + `nonisolated` because the AppDelegate `open url` hook
+  /// expects an immediate `Bool`, matching `SpotifyAuthCoordinator.handleOpenURL`.
+  nonisolated func handleAuthorizeRedirect(_ url: URL) -> Bool {
+    guard let remote = pendingAuthorizeRemote else { return false }
+    let consume: () -> Bool = { [self] in
+      MainActor.assumeIsolated {
+        let params = remote.authorizationParameters(from: url)
+        if let token = params?[SPTAppRemoteAccessTokenKey] {
+          remote.connectionParameters.accessToken = token
+          pendingAuthorizeRemote = nil
+          remote.connect()
+          return true
+        } else if let errorDescription = params?[SPTAppRemoteErrorDescriptionKey] {
+          pendingAuthorizeRemote = nil
+          Task {
+            await self.didFailToConnect(error: NSError(
+              domain: "ExpoSpotifySDK",
+              code: -2,
+              userInfo: [NSLocalizedDescriptionKey: errorDescription]
+            ))
+          }
+          return true
+        }
+        return false
+      }
+    }
+    if Thread.isMainThread {
+      return consume()
+    }
+    return DispatchQueue.main.sync(execute: consume)
+  }
+
   func disconnect() {
     if let cont = connectContinuation {
       connectContinuation = nil
@@ -106,6 +210,7 @@ actor SpotifyAppRemoteCoordinator {
     teardownCapabilitiesSubscription()
     appRemote?.disconnect()
     appRemote = nil
+    pendingAuthorizeRemote = nil
     transitionState("disconnected")
   }
 
@@ -120,6 +225,7 @@ actor SpotifyAppRemoteCoordinator {
   // MARK: — Connection delegate callbacks
 
   func didConnect() {
+    pendingAuthorizeRemote = nil
     transitionState("connected")
     setupPlayerSubscription()
     setupCapabilitiesSubscription()
@@ -130,6 +236,7 @@ actor SpotifyAppRemoteCoordinator {
 
   func didFailToConnect(error: Error?) {
     appRemote = nil
+    pendingAuthorizeRemote = nil
     let msg = error.map { describeNSError($0 as NSError) } ?? "Unknown connection failure"
     let remoteError = AppRemoteError.connectionFailed(msg)
     transitionState("disconnected")

--- a/ios/SpotifyAppRemoteCoordinator.swift
+++ b/ios/SpotifyAppRemoteCoordinator.swift
@@ -149,16 +149,20 @@ actor SpotifyAppRemoteCoordinator {
     try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
       self.connectContinuation = cont
       Task { @MainActor in
-        // `authorizeAndPlayURI` returns false synchronously when the Spotify
-        // app is not installed — no redirect will ever arrive, so fail now.
-        let launched = remote.authorizeAndPlayURI(uri)
-        if !launched {
-          Task {
-            await self.didFailToConnect(error: NSError(
-              domain: "ExpoSpotifySDK",
-              code: -1,
-              userInfo: [NSLocalizedDescriptionKey: "authorizeAndPlay: the Spotify app is not installed"]
-            ))
+        // `authorizeAndPlayURI` app-switches to Spotify to wake it. `success`
+        // is false when the Spotify app could not be opened (e.g. not
+        // installed) — no redirect will arrive, so fail the continuation now.
+        // On success we await the redirect, handled by
+        // `handleAuthorizeRedirect(_:)`, which completes the connection.
+        remote.authorizeAndPlayURI(uri) { success in
+          if !success {
+            Task {
+              await self.didFailToConnect(error: NSError(
+                domain: "ExpoSpotifySDK",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "authorizeAndPlay: could not open the Spotify app (is it installed?)"]
+              ))
+            }
           }
         }
       }

--- a/src/app-remote/index.ts
+++ b/src/app-remote/index.ts
@@ -85,6 +85,46 @@ export const AppRemote = {
   },
 
   /**
+   * Wakes the Spotify app — launching it if it has been suspended in the
+   * background — starts playback, and then establishes the App Remote
+   * connection. This is the recommended way to (re)connect when Spotify may
+   * not currently be running.
+   *
+   * Why this exists: {@link connect} only attaches to an *already-running*
+   * Spotify process. If Spotify has been suspended (e.g. iOS reclaims a
+   * backgrounded app that isn't playing audio, or the connection dropped
+   * ~30s after the user paused), `connect()` rejects with `CONNECTION_FAILED`
+   * and there is no way to revive Spotify from `connect()` alone.
+   * `authorizeAndPlay()` performs an app-switch to Spotify
+   * (iOS `authorizeAndPlayURI`; Android wakes the App Remote service and
+   * issues a play command), which both revives Spotify and keeps it alive by
+   * starting audio.
+   *
+   * Trade-offs:
+   * - It **always starts (or resumes) playback** — it cannot wake Spotify
+   *   silently.
+   * - It briefly **switches to the Spotify app** and back; the OS does not
+   *   allow waking another app without a foreground app-switch.
+   * - Requires Spotify Premium for on-demand playback of a specific `uri`.
+   *
+   * @param accessToken Access token from `Auth.authenticate()`. On Android this
+   *   is an iOS-parity parameter (see {@link connect}); on iOS the token
+   *   returned by the authorization redirect is used to complete the connection.
+   * @param uri Spotify URI to play. Pass an empty string (the default) to
+   *   resume the user's last track or play a contextual/random track.
+   *
+   * Resolves once Spotify is connected and the play command has been issued;
+   * rejects with an {@link AppRemoteError} if Spotify is not installed or the
+   * authorization is denied.
+   */
+  authorizeAndPlay(accessToken: string, uri: string = ""): Promise<void> {
+    return ExpoSpotifySDKModule.appRemoteAuthorizeAndPlay(
+      accessToken,
+      uri,
+    ).catch(rethrowAsAppRemoteError);
+  },
+
+  /**
    * Disconnects from the Spotify app. Safe to call when already disconnected.
    * Resolves once the disconnection is complete.
    */


### PR DESCRIPTION
Closes #53.

## What

Adds `AppRemote.authorizeAndPlay(accessToken, uri?)` — wakes the Spotify app (launching it if suspended), starts playback, then establishes the App Remote connection. This is the recommended recovery when `connect()` fails with `CONNECTION_FAILED` because Spotify was suspended (iOS background reclaim, or the ~30s post-pause drop). See #53 for the full rationale.

## How

- **JS** (`src/app-remote/index.ts`) — new `authorizeAndPlay(accessToken, uri = "")` method, fully JSDoc'd with trade-offs.
- **iOS** — `SpotifyAppRemoteCoordinator.authorizeAndPlay` calls `authorizeAndPlayURI`; a new `handleAuthorizeRedirect(_:)` consumes the authorization redirect and completes `connect()` on the same `SPTAppRemote`. `ExpoSpotifyAppDelegate` now offers `open url` to the App Remote coordinator first (it only claims a redirect while an authorize flow is pending) before falling back to `SpotifyAuthCoordinator`. The existing `connectContinuation` is reused so `didConnect`/`didFailToConnect` resolve uniformly; pending state is cleared on all teardown paths.
- **Android** — `connect()` (already wakes the Spotify service) then `playerApi.play(uri)` / `resume()` for empty uri.
- **Docs** — README troubleshooting + `docs/api-reference.md` point `CONNECTION_FAILED` recovery at the new method.

## Semantics

- Empty `uri` (default) resumes the user's last/contextual track.
- Always starts/resumes playback and briefly app-switches to Spotify — cannot wake Spotify silently.
- On-demand `uri` playback requires Premium.

## Verification

- ✅ `yarn typecheck`, `yarn test` (52/52), `yarn lint` (only pre-existing warnings), `yarn build`.
- ⚠️ **Draft pending on-device QA.** The native app-switch + redirect flow has not been exercised on a device. Specifically wants verification on iOS + Android (Spotify installed + Premium):
  1. A normal auth redirect is **not** accidentally consumed by the new App Remote redirect handler (disambiguation).
  2. The `nonisolated(unsafe)` access to `pendingAuthorizeRemote` from the main-thread redirect handler is sound.
  3. `authorizeAndPlayURI` returning `false` (Spotify not installed) surfaces as `CONNECTION_FAILED`.

## Checklist

- [x] `yarn test` passes
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes (pre-existing warnings only)
- [x] Conventional Commits
- [x] New public API annotated with JSDoc
- [x] README updated
- [ ] On-device QA (iOS + Android) — pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `authorizeAndPlay(accessToken, uri?)` method to App Remote API, enabling reconnection when Spotify is suspended and automatically initiating or resuming playback.

* **Documentation**
  * Updated iOS and Android troubleshooting guidance for connection failures, recommending `authorizeAndPlay()` as the primary resolution approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->