### PR TITLE
ci: enable Release Please on v1 lane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, v1]
 
 permissions:
   contents: write
@@ -20,6 +20,7 @@ jobs:
         id: rp
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -47,6 +48,11 @@ jobs:
         run: yarn prepublishOnly
 
       - name: Publish
-        run: npm publish --provenance --access public
+        run: |
+          if [ "${{ github.ref_name }}" = "v1" ]; then
+            npm publish --provenance --access public --tag sdk55
+          else
+            npm publish --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,7 +49,7 @@ Both lanes ship the full Auth + App Remote API ([ADR-0006](./docs/adr/0006-names
 ### `1.x` on `v1` (Expo SDK 55)
 
 - npm **`1.x`**, branch **`v1`**, iOS 15.1+, `expo-modules-core@^3.x`
-- **`1.0.0`** is published; install with `npm install @wwdrew/expo-spotify-sdk@1` (or pin `1.x.y`)
+- **`1.0.0`** is published; install with `npm install @wwdrew/expo-spotify-sdk@1` (or `@sdk55`; releases from `v1` use that dist-tag so `latest` stays on `2.x`)
 - Config plugin: string/tuple form in `app.json` / `app.config.ts` only
 
 ### `2.x` on `main` (Expo SDK 56+)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ When changing App Remote error mapping on iOS or Android, update both native map
 
 ## Release process
 
-- **`2.x` from `main`** — [Release Please](https://github.com/googleapis/release-please) opens a release PR; merging it publishes to npm (see [docs/RELEASE.md](docs/RELEASE.md)).
-- **`1.x` from `v1`** — maintenance releases from the `v1` branch (see [docs/RELEASE.md](docs/RELEASE.md)).
+- **`2.x` from `main`** — [Release Please](https://github.com/googleapis/release-please) opens a release PR; merging it publishes to npm as **`latest`** (see [docs/RELEASE.md](docs/RELEASE.md)).
+- **`1.x` from `v1`** — same Release Please flow on the `v1` branch; merging publishes with npm dist-tag **`sdk55`** (see [docs/RELEASE.md](docs/RELEASE.md)).
 
 Use Conventional Commits on the branch you are releasing from.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Top-level v0-style functions were removed in **`2.x`**. If you still use them, s
 npx expo install @wwdrew/expo-spotify-sdk
 
 # Expo SDK 55 only: npx expo install @wwdrew/expo-spotify-sdk@1
+# (or @sdk55 — npm dist-tag for the v1 maintenance lane)
 
 # 2. Add the config plugin to app.config.ts / app.json  (see Configuration below)
 # 3. Regenerate native projects

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,10 +2,10 @@
 
 Two long-lived branches, two npm majors. See [ADR-0005](./adr/0005-sdk-lane-versioning.md).
 
-| Branch | npm major | Expo SDK | iOS min | Status |
-| --- | --- | --- | --- | --- |
-| **`main`** | `2.x` | 56+ | 16.4 | Active development; default for new work |
-| **`v1`** | `1.x` | 55 | 15.1 | Maintenance; bugfixes and security backports |
+| Branch | npm major | npm dist-tag | Expo SDK | iOS min | Status |
+| --- | --- | --- | --- | --- | --- |
+| **`main`** | `2.x` | `latest` (default) | 56+ | 16.4 | Active development; default for new work |
+| **`v1`** | `1.x` | `sdk55` | 55 | 15.1 | Maintenance; bugfixes and security backports |
 
 ---
 
@@ -61,13 +61,36 @@ Follow [QA_CHECKLIST.md](./QA_CHECKLIST.md) on the **SDK 55** toolchain (`v1` ch
 
 ### Publish
 
-Configure Release Please (or your process) so **`1.x.y` releases run from `v1`**, not `main`. Until that is wired, maintainers can publish manually from `v1` after a version bump.
+Releases are automated via [Release Please](https://github.com/googleapis/release-please) on **`v1`** (same workflow as `main`, scoped with `target-branch`):
 
-`1.0.0` is already on npm from the initial SDK 55 release (tag `expo-spotify-sdk-v1.0.0`).
+1. Cherry-pick or land conventional commits on `v1` (`fix:`, `feat:`, etc.).
+2. Release Please opens/updates a release PR on `v1` (e.g. `chore(v1): release expo-spotify-sdk 1.0.1`).
+3. Merge that PR → GitHub Release + **npm publish** with dist-tag **`sdk55`** (not `latest`).
+
+Install for consumers:
+
+```sh
+npm install @wwdrew/expo-spotify-sdk@1
+# or explicitly:
+npm install @wwdrew/expo-spotify-sdk@sdk55
+```
+
+`1.0.0` is already on npm from the initial SDK 55 release (git tag `expo-spotify-sdk-v1.0.0`).
+
+#### One-time setup
+
+1. **Workflow on `v1`** — GitHub Actions runs the workflow file **from the branch that was pushed**. Merge `.github/workflows/release.yml` into **`v1`** (cherry-pick from `main`) before the first automated `1.x.y` release. Until then, pushes to `v1` will not trigger Release Please.
+
+2. **`sdk55` dist-tag on `1.0.0`** (if not already set):
+
+   ```sh
+   npm dist-tag add @wwdrew/expo-spotify-sdk@1.0.0 sdk55
+   ```
 
 ### Post-release
 
 - [ ] GitHub Release notes mention **Expo SDK 55**
+- [ ] npm **`latest`** still points at the current **`2.x`** (a mistaken `v1` publish without `--tag sdk55` would steal `latest` — fix with `npm dist-tag add @wwdrew/expo-spotify-sdk@<2.x> latest`)
 - [ ] README on `v1` (if branched docs differ) still directs SDK 56 consumers to `2.x` on `main`
 
 ---

--- a/docs/adr/0005-sdk-lane-versioning.md
+++ b/docs/adr/0005-sdk-lane-versioning.md
@@ -71,8 +71,8 @@ Completed per [V1_PLAN.md §6 Phases 6–7](../V1_PLAN.md#6-implementation-phase
 | Migrate **`main`** to SDK 56; `package.json` → `2.0.0` | `main` | ✅ |
 | Typed config plugin `@wwdrew/expo-spotify-sdk/plugin` | `main` only | ✅ |
 | README lane table (`1.x` / `v1`, `2.x` / `main`) | `main` | ✅ |
-| Publish **`2.0.0`** via Release Please on `main` | npm | ⬜ pending |
-| Release Please for **`1.x.y`** from `v1` | `v1` | ⬜ optional follow-up |
+| Publish **`2.x`** via Release Please on `main` | npm `latest` | ✅ |
+| Release Please for **`1.x.y`** from `v1` | npm `sdk55` | ✅ (workflow; merge `release.yml` onto `v1` before first run) |
 
 ## Validation
 


### PR DESCRIPTION
## Summary
- Run Release Please on both `main` and `v1` with `target-branch` scoping per lane
- Publish `1.x` releases with npm dist-tag `sdk55` so `latest` stays on `2.x`
- Document dual-lane release flow in RELEASE.md, CONTRIBUTING.md, and ADR-0005

## Already done on `v1`
The workflow change is already pushed to `origin/v1` (`d41a0b9`) so v1 pushes will trigger release-please once this merges to `main` (both branches need the same workflow shape; v1 is live now).

## Test plan
- [ ] Merge to `main` and confirm Release Please still opens/updates release PRs on `main`
- [ ] Push a conventional commit to `v1` and confirm release-please opens a PR on `v1`
- [ ] Verify `npm view @wwdrew/expo-spotify-sdk dist-tags` shows `latest: 2.x` and `sdk55: 1.x` after a v1 release


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified npm dist-tag strategy for v1 maintenance releases
  * Updated installation guidance for Expo SDK 55 users
  * Enhanced documentation of parallel release lane processes and versioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->