### PR TITLE
refactor(ios): extract App Remote connection lifecycle

### DIFF
--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -51,6 +51,7 @@ On **`main`**, you can also exercise the **typed config plugin** in `app.config.
 | R3 | `AppRemote.disconnect()` returns to `disconnected` | ☐ | ☐ |
 | R4 | Connect with Spotify backgrounded — graceful failure, no infinite retry loop | ☐ | ☐ |
 | R5 | `connectionError` surfaced on failure / drop | ☐ | ☐ |
+| R6 | `authorizeAndPlay()` recovers when Spotify suspended (iOS) | ☐ | ☐ |
 
 ## Player (Premium account)
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -22,7 +22,7 @@ App Remote native → JS mapping details: [app-remote-error-mapping.md](./app-re
 
 | Code | When | What to do |
 | --- | --- | --- |
-| `CONNECTION_FAILED` | `connect()` failed (app missing, refused, handshake error) | Open Spotify foreground; re-auth if token stale; retry once |
+| `CONNECTION_FAILED` | `connect()` failed (app missing, refused, handshake error) | Try `AppRemote.authorizeAndPlay(token)` if Spotify may be suspended; otherwise foreground Spotify and retry `connect()`; re-auth if token stale |
 | `CONNECTION_LOST` | Connection dropped mid-session | `AppRemote.connect()` again with fresh token |
 | `NOT_CONNECTED` | `AppRemote.*` called before connect completed | `await AppRemote.connect()` first |
 | `UNKNOWN` | Unexpected IPC failure | Read `e.message`; retry connect |

--- a/ios/SpotifyAppRemoteConnection.swift
+++ b/ios/SpotifyAppRemoteConnection.swift
@@ -1,0 +1,221 @@
+import Foundation
+import SpotifyiOS
+import UIKit
+
+// MARK: — Connection models
+
+enum AppRemoteConnectionKickoff: Equatable {
+  case directConnect
+  case authorizeAndPlay(uri: String)
+}
+
+struct AppRemoteConnectionAttempt {
+  let remote: SPTAppRemote
+  let kickoff: AppRemoteConnectionKickoff
+}
+
+// MARK: — Connection lifecycle
+
+extension SpotifyAppRemoteCoordinator {
+  func connect(accessToken: String) async throws {
+    if appRemote?.isConnected == true { return }
+    try await beginConnection(accessToken: accessToken, kickoff: .directConnect)
+  }
+
+  /// Wakes the Spotify app (via `authorizeAndPlayURI`), starts playback, and
+  /// then completes the App Remote connection once Spotify redirects back.
+  ///
+  /// Unlike `connect()`, this works even when the Spotify app has been
+  /// suspended: `authorizeAndPlayURI` performs an app-switch to Spotify, which
+  /// revives it. Spotify then redirects back to the host app with an access
+  /// token; `handleAuthorizeRedirect(_:)` consumes that redirect and calls
+  /// `connect()` on the same `SPTAppRemote` instance.
+  ///
+  /// The `connectContinuation` is reused for the whole flow, so `didConnect()`
+  /// / `didFailToConnect(error:)` resolve it exactly as for `connect()`.
+  func authorizeAndPlay(uri: String, accessToken: String) async throws {
+    if appRemote?.isConnected == true {
+      if uri.isEmpty {
+        try await playerResume()
+      } else {
+        try await playerPlay(uri: uri)
+      }
+      return
+    }
+    try await beginConnection(
+      accessToken: accessToken,
+      kickoff: .authorizeAndPlay(uri: uri),
+    )
+  }
+
+  /// Consumes a redirect URL produced by an `authorizeAndPlay()` app-switch.
+  /// Returns `true` if an authorize flow was pending and the URL was handled
+  /// (so the AppDelegate should not also forward it to the auth coordinator).
+  nonisolated func handleAuthorizeRedirect(_ url: URL) -> Bool {
+    guard case .authorizeAndPlay = connectionAttempt?.kickoff,
+          let remote = connectionAttempt?.remote
+    else {
+      return false
+    }
+
+    return SpotifyMainThread.run {
+      let params = remote.authorizationParameters(from: url)
+      if let token = params?[SPTAppRemoteAccessTokenKey] {
+        remote.connectionParameters.accessToken = token
+        clearConnectionAttempt()
+        remote.connect()
+        return true
+      }
+      if let errorDescription = params?[SPTAppRemoteErrorDescriptionKey] {
+        clearConnectionAttempt()
+        Task {
+          await self.didFailToConnect(error: NSError(
+            domain: "ExpoSpotifySDK",
+            code: -2,
+            userInfo: [NSLocalizedDescriptionKey: errorDescription]
+          ))
+        }
+        return true
+      }
+      return false
+    }
+  }
+
+  func disconnect() {
+    if let cont = connectContinuation {
+      connectContinuation = nil
+      cont.resume(throwing: AppRemoteError.connectionFailed("Disconnected before connection completed"))
+    }
+    teardownPlayerSubscription()
+    teardownCapabilitiesSubscription()
+    appRemote?.disconnect()
+    appRemote = nil
+    clearConnectionAttempt()
+    transitionState("disconnected")
+  }
+
+  nonisolated func isConnected() -> Bool {
+    connectionStateString == "connected"
+  }
+
+  func getConnectionState() -> String {
+    connectionStateString
+  }
+
+  func didConnect() {
+    clearConnectionAttempt()
+    transitionState("connected")
+    setupPlayerSubscription()
+    setupCapabilitiesSubscription()
+    let cont = connectContinuation
+    connectContinuation = nil
+    cont?.resume()
+  }
+
+  func didFailToConnect(error: Error?) {
+    appRemote = nil
+    clearConnectionAttempt()
+    let msg = error.map { describeNSError($0 as NSError) } ?? "Unknown connection failure"
+    let remoteError = AppRemoteError.connectionFailed(msg)
+    transitionState("disconnected")
+    onConnectionError?(remoteError.code, remoteError.message)
+    let cont = connectContinuation
+    connectContinuation = nil
+    cont?.resume(throwing: remoteError)
+  }
+
+  func didDisconnect(error: Error?) {
+    appRemote = nil
+    transitionState("disconnected")
+    if let error = error {
+      let msg = describeNSError(error as NSError)
+      onConnectionError?(AppRemoteError.connectionLost(msg).code, msg)
+    }
+  }
+
+  // MARK: — Private connection helpers
+
+  private func beginConnection(
+    accessToken: String,
+    kickoff: AppRemoteConnectionKickoff,
+  ) async throws {
+    guard connectContinuation == nil else {
+      throw AppRemoteError.connectionFailed("A connection attempt is already in progress")
+    }
+
+    transitionState("connecting")
+
+    let remote = makeAppRemote(accessToken: accessToken)
+    appRemote = remote
+    connectionAttempt = AppRemoteConnectionAttempt(remote: remote, kickoff: kickoff)
+
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+      connectContinuation = cont
+      Task { @MainActor in
+        switch kickoff {
+        case .directConnect:
+          remote.connect()
+        case .authorizeAndPlay(let uri):
+          let success = await remote.authorizeAndPlayURI(uri)
+          if !success {
+            await self.didFailToConnect(error: Self.authorizeOpenFailedError())
+          }
+        }
+      }
+    }
+  }
+
+  private func makeAppRemote(accessToken: String) -> SPTAppRemote {
+    let params = SPTAppRemoteConnectionParams(
+      accessToken: accessToken,
+      defaultImageSize: CGSize.zero,
+      imageFormat: .any
+    )
+    let remote = SPTAppRemote(
+      configuration: sptConfiguration,
+      connectionParameters: params,
+      logLevel: .error
+    )
+    remote.delegate = connectionBridge
+    return remote
+  }
+
+  nonisolated private func clearConnectionAttempt() {
+    connectionAttempt = nil
+  }
+
+  private static func authorizeOpenFailedError() -> NSError {
+    NSError(
+      domain: "ExpoSpotifySDK",
+      code: -1,
+      userInfo: [
+        NSLocalizedDescriptionKey:
+          "authorizeAndPlay: could not open the Spotify app (is it installed?)",
+      ]
+    )
+  }
+}
+
+// MARK: — Connection delegate bridge
+
+/// `SPTAppRemoteDelegate` requires `NSObject` conformance, which an `actor`
+/// cannot satisfy directly. This bridge is a tiny `NSObject` that hops each
+/// delegate callback onto the actor's executor via a `Task`.
+final class SpotifyAppRemoteDelegateBridge: NSObject, SPTAppRemoteDelegate {
+  weak var coordinator: SpotifyAppRemoteCoordinator?
+
+  func appRemoteDidEstablishConnection(_ appRemote: SPTAppRemote) {
+    NSLog("[ExpoSpotifySDK] AppRemote: connection established")
+    Task { await coordinator?.didConnect() }
+  }
+
+  func appRemote(_ appRemote: SPTAppRemote, didFailConnectionAttemptWithError error: (any Error)?) {
+    NSLog("[ExpoSpotifySDK] AppRemote: connection failed — %@", String(describing: error))
+    Task { await coordinator?.didFailToConnect(error: error) }
+  }
+
+  func appRemote(_ appRemote: SPTAppRemote, didDisconnectWithError error: (any Error)?) {
+    NSLog("[ExpoSpotifySDK] AppRemote: disconnected — %@", String(describing: error))
+    Task { await coordinator?.didDisconnect(error: error) }
+  }
+}

--- a/ios/SpotifyAppRemoteCoordinator.swift
+++ b/ios/SpotifyAppRemoteCoordinator.swift
@@ -18,20 +18,16 @@ import UIKit
 actor SpotifyAppRemoteCoordinator {
   static let shared: SpotifyAppRemoteCoordinator? = SpotifyAppRemoteCoordinator.create()
 
-  private let sptConfiguration: SPTConfiguration
-  private let connectionBridge: SpotifyAppRemoteDelegateBridge
+  let sptConfiguration: SPTConfiguration
+  let connectionBridge: SpotifyAppRemoteDelegateBridge
   private let playerStateBridge: SpotifyPlayerStateDelegateBridge
   private let userCapabilitiesBridge: SpotifyUserCapabilitiesDelegateBridge
-  private var appRemote: SPTAppRemote?
-  private var connectContinuation: CheckedContinuation<Void, Error>?
+  var appRemote: SPTAppRemote?
+  var connectContinuation: CheckedContinuation<Void, Error>?
 
-  /// The `SPTAppRemote` awaiting an `authorizeAndPlay()` redirect, exposed
-  /// synchronously to the URL-redirect path. Mirrors the auth coordinator's
-  /// `nonisolated(unsafe)` `sessionManager`: it is only written from the
-  /// actor's executor (or the main-thread redirect handler) and read on the
-  /// main thread, so occasional cross-actor access is acceptable. `nil`
-  /// whenever no authorize-and-play flow is in flight.
-  nonisolated(unsafe) private var pendingAuthorizeRemote: SPTAppRemote?
+  /// In-flight connection attempt, readable from the synchronous redirect path.
+  /// `nil` whenever no connection attempt is active.
+  nonisolated(unsafe) var connectionAttempt: AppRemoteConnectionAttempt?
 
   nonisolated(unsafe) private(set) var connectionStateString: String = "disconnected"
 
@@ -76,195 +72,15 @@ actor SpotifyAppRemoteCoordinator {
     return SpotifyAppRemoteCoordinator(sptConfiguration: sptConfig)
   }
 
-  // MARK: — Connection lifecycle
-
-  func connect(accessToken: String) async throws {
-    if appRemote?.isConnected == true { return }
-    guard connectContinuation == nil else {
-      throw AppRemoteError.connectionFailed("A connection attempt is already in progress")
-    }
-
-    transitionState("connecting")
-
-    let params = SPTAppRemoteConnectionParams(
-      accessToken: accessToken,
-      defaultImageSize: CGSize.zero,
-      imageFormat: .any
-    )
-    let remote = SPTAppRemote(
-      configuration: sptConfiguration,
-      connectionParameters: params,
-      logLevel: .error
-    )
-    remote.delegate = connectionBridge
-    appRemote = remote
-
-    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-      self.connectContinuation = cont
-      Task { @MainActor in remote.connect() }
-    }
-  }
-
-  /// Wakes the Spotify app (via `authorizeAndPlayURI`), starts playback, and
-  /// then completes the App Remote connection once Spotify redirects back.
-  ///
-  /// Unlike `connect()`, this works even when the Spotify app has been
-  /// suspended: `authorizeAndPlayURI` performs an app-switch to Spotify, which
-  /// revives it. Spotify then redirects back to the host app with an access
-  /// token; `handleAuthorizeRedirect(_:)` consumes that redirect and calls
-  /// `connect()` on the same `SPTAppRemote` instance.
-  ///
-  /// The `connectContinuation` is reused for the whole flow, so `didConnect()`
-  /// / `didFailToConnect(error:)` resolve it exactly as for `connect()`.
-  func authorizeAndPlay(uri: String, accessToken: String) async throws {
-    if appRemote?.isConnected == true {
-      // Already connected — honour the request by (re)starting playback.
-      if uri.isEmpty {
-        try await playerResume()
-      } else {
-        try await playerPlay(uri: uri)
-      }
-      return
-    }
-    guard connectContinuation == nil else {
-      throw AppRemoteError.connectionFailed("A connection attempt is already in progress")
-    }
-
-    transitionState("connecting")
-
-    let params = SPTAppRemoteConnectionParams(
-      accessToken: accessToken,
-      defaultImageSize: CGSize.zero,
-      imageFormat: .any
-    )
-    let remote = SPTAppRemote(
-      configuration: sptConfiguration,
-      connectionParameters: params,
-      logLevel: .error
-    )
-    remote.delegate = connectionBridge
-    appRemote = remote
-    pendingAuthorizeRemote = remote
-
-    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-      self.connectContinuation = cont
-      Task { @MainActor in
-        // `authorizeAndPlayURI` app-switches to Spotify to wake it. `success`
-        // is false when the Spotify app could not be opened (e.g. not
-        // installed) — no redirect will arrive, so fail the continuation now.
-        // On success we await the redirect, handled by
-        // `handleAuthorizeRedirect(_:)`, which completes the connection.
-        let success = await remote.authorizeAndPlayURI(uri)
-        if !success {
-          await self.didFailToConnect(error: NSError(
-            domain: "ExpoSpotifySDK",
-            code: -1,
-            userInfo: [NSLocalizedDescriptionKey: "authorizeAndPlay: could not open the Spotify app (is it installed?)"]
-          ))
-        }
-      }
-    }
-  }
-
-  /// Consumes a redirect URL produced by an `authorizeAndPlay()` app-switch.
-  /// Returns `true` if an authorize flow was pending and the URL was handled
-  /// (so the AppDelegate should not also forward it to the auth coordinator).
-  ///
-  /// Synchronous + `nonisolated` because the AppDelegate `open url` hook
-  /// expects an immediate `Bool`, matching `SpotifyAuthCoordinator.handleOpenURL`.
-  nonisolated func handleAuthorizeRedirect(_ url: URL) -> Bool {
-    guard let remote = pendingAuthorizeRemote else { return false }
-    let consume: () -> Bool = { [self] in
-      MainActor.assumeIsolated {
-        let params = remote.authorizationParameters(from: url)
-        if let token = params?[SPTAppRemoteAccessTokenKey] {
-          remote.connectionParameters.accessToken = token
-          pendingAuthorizeRemote = nil
-          remote.connect()
-          return true
-        } else if let errorDescription = params?[SPTAppRemoteErrorDescriptionKey] {
-          pendingAuthorizeRemote = nil
-          Task {
-            await self.didFailToConnect(error: NSError(
-              domain: "ExpoSpotifySDK",
-              code: -2,
-              userInfo: [NSLocalizedDescriptionKey: errorDescription]
-            ))
-          }
-          return true
-        }
-        return false
-      }
-    }
-    if Thread.isMainThread {
-      return consume()
-    }
-    return DispatchQueue.main.sync(execute: consume)
-  }
-
-  func disconnect() {
-    if let cont = connectContinuation {
-      connectContinuation = nil
-      cont.resume(throwing: AppRemoteError.connectionFailed("Disconnected before connection completed"))
-    }
-    teardownPlayerSubscription()
-    teardownCapabilitiesSubscription()
-    appRemote?.disconnect()
-    appRemote = nil
-    pendingAuthorizeRemote = nil
-    transitionState("disconnected")
-  }
-
-  nonisolated func isConnected() -> Bool {
-    connectionStateString == "connected"
-  }
-
-  func getConnectionState() -> String {
-    connectionStateString
-  }
-
-  // MARK: — Connection delegate callbacks
-
-  func didConnect() {
-    pendingAuthorizeRemote = nil
-    transitionState("connected")
-    setupPlayerSubscription()
-    setupCapabilitiesSubscription()
-    let cont = connectContinuation
-    connectContinuation = nil
-    cont?.resume()
-  }
-
-  func didFailToConnect(error: Error?) {
-    appRemote = nil
-    pendingAuthorizeRemote = nil
-    let msg = error.map { describeNSError($0 as NSError) } ?? "Unknown connection failure"
-    let remoteError = AppRemoteError.connectionFailed(msg)
-    transitionState("disconnected")
-    onConnectionError?(remoteError.code, remoteError.message)
-    let cont = connectContinuation
-    connectContinuation = nil
-    cont?.resume(throwing: remoteError)
-  }
-
-  func didDisconnect(error: Error?) {
-    appRemote = nil
-    transitionState("disconnected")
-    if let error = error {
-      let msg = describeNSError(error as NSError)
-      onConnectionError?(AppRemoteError.connectionLost(msg).code, msg)
-    }
-  }
-
   // MARK: — Player subscription
 
-  private func setupPlayerSubscription() {
+  func setupPlayerSubscription() {
     guard let playerAPI = appRemote?.playerAPI else { return }
     playerAPI.delegate = playerStateBridge
     playerAPI.subscribe(toPlayerState: { _, _ in })
   }
 
-  private func teardownPlayerSubscription() {
+  func teardownPlayerSubscription() {
     guard let playerAPI = appRemote?.playerAPI else { return }
     playerAPI.delegate = nil
     playerAPI.unsubscribe(toPlayerState: { _, _ in })
@@ -277,13 +93,13 @@ actor SpotifyAppRemoteCoordinator {
 
   // MARK: — User subscription
 
-  private func setupCapabilitiesSubscription() {
+  func setupCapabilitiesSubscription() {
     guard let userAPI = appRemote?.userAPI else { return }
     userAPI.delegate = userCapabilitiesBridge
     userAPI.subscribe(toCapabilityChanges: { _, _ in })
   }
 
-  private func teardownCapabilitiesSubscription() {
+  func teardownCapabilitiesSubscription() {
     guard let userAPI = appRemote?.userAPI else { return }
     userAPI.delegate = nil
     userAPI.unsubscribe(toCapabilityChanges: { _, _ in })
@@ -598,12 +414,12 @@ actor SpotifyAppRemoteCoordinator {
     }
   }
 
-  private func transitionState(_ state: String) {
+  func transitionState(_ state: String) {
     connectionStateString = state
     onConnectionStateChange?(state)
   }
 
-  private func describeNSError(_ error: NSError) -> String {
+  func describeNSError(_ error: NSError) -> String {
     var parts: [String] = ["\(error.domain) code \(error.code)"]
     let desc = error.localizedDescription
     if !desc.isEmpty { parts.append("\"\(desc)\"") }
@@ -611,30 +427,6 @@ actor SpotifyAppRemoteCoordinator {
       parts.append("→ \(describeNSError(underlying))")
     }
     return parts.joined(separator: " ")
-  }
-}
-
-// MARK: — Connection delegate bridge
-
-/// `SPTAppRemoteDelegate` requires `NSObject` conformance, which an `actor`
-/// cannot satisfy directly. This bridge is a tiny `NSObject` that hops each
-/// delegate callback onto the actor's executor via a `Task`.
-final class SpotifyAppRemoteDelegateBridge: NSObject, SPTAppRemoteDelegate {
-  weak var coordinator: SpotifyAppRemoteCoordinator?
-
-  func appRemoteDidEstablishConnection(_ appRemote: SPTAppRemote) {
-    NSLog("[ExpoSpotifySDK] AppRemote: connection established")
-    Task { await coordinator?.didConnect() }
-  }
-
-  func appRemote(_ appRemote: SPTAppRemote, didFailConnectionAttemptWithError error: (any Error)?) {
-    NSLog("[ExpoSpotifySDK] AppRemote: connection failed — %@", String(describing: error))
-    Task { await coordinator?.didFailToConnect(error: error) }
-  }
-
-  func appRemote(_ appRemote: SPTAppRemote, didDisconnectWithError error: (any Error)?) {
-    NSLog("[ExpoSpotifySDK] AppRemote: disconnected — %@", String(describing: error))
-    Task { await coordinator?.didDisconnect(error: error) }
   }
 }
 

--- a/ios/SpotifyAuthCoordinator.swift
+++ b/ios/SpotifyAuthCoordinator.swift
@@ -1,6 +1,7 @@
 import ExpoModulesCore
 import Foundation
 import SpotifyiOS
+import UIKit
 
 /// Public, structured errors thrown by the coordinator. Each case carries the
 /// JS-facing error code in `code`, mirroring the Android `CodedException`
@@ -105,15 +106,9 @@ actor SpotifyAuthCoordinator {
   /// Synchronous URL-handler dispatcher used by the AppDelegate / SceneDelegate
   /// subscribers to forward redirects to the SPTSessionManager.
   nonisolated func handleOpenURL(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-    let openSession: () -> Bool = { [self] in
-      MainActor.assumeIsolated {
-        sessionManager.application(UIApplication.shared, open: url, options: options)
-      }
+    SpotifyMainThread.run {
+      sessionManager.application(UIApplication.shared, open: url, options: options)
     }
-    if Thread.isMainThread {
-      return openSession()
-    }
-    return DispatchQueue.main.sync(execute: openSession)
   }
 
   func authenticate(

--- a/ios/SpotifyMainThread.swift
+++ b/ios/SpotifyMainThread.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Runs a block on the main thread, matching AppDelegate / SceneDelegate redirect
+/// hooks that require a synchronous result from the main actor.
+enum SpotifyMainThread {
+  static func run<T>(_ block: @MainActor () -> T) -> T {
+    if Thread.isMainThread {
+      return MainActor.assumeIsolated(block)
+    }
+    return DispatchQueue.main.sync {
+      MainActor.assumeIsolated(block)
+    }
+  }
+}

--- a/src/app-remote/index.ts
+++ b/src/app-remote/index.ts
@@ -85,37 +85,12 @@ export const AppRemote = {
   },
 
   /**
-   * Wakes the Spotify app — launching it if it has been suspended in the
-   * background — starts playback, and then establishes the App Remote
-   * connection. This is the recommended way to (re)connect when Spotify may
-   * not currently be running.
+   * Wakes Spotify (launching if suspended), starts or resumes playback, and
+   * connects. Use when {@link connect} may fail because Spotify is not running.
+   * Always foregrounds Spotify and starts audio — see package api-reference.
    *
-   * Why this exists: {@link connect} only attaches to an *already-running*
-   * Spotify process. If Spotify has been suspended (e.g. iOS reclaims a
-   * backgrounded app that isn't playing audio, or the connection dropped
-   * ~30s after the user paused), `connect()` rejects with `CONNECTION_FAILED`
-   * and there is no way to revive Spotify from `connect()` alone.
-   * `authorizeAndPlay()` performs an app-switch to Spotify
-   * (iOS `authorizeAndPlayURI`; Android wakes the App Remote service and
-   * issues a play command), which both revives Spotify and keeps it alive by
-   * starting audio.
-   *
-   * Trade-offs:
-   * - It **always starts (or resumes) playback** — it cannot wake Spotify
-   *   silently.
-   * - It briefly **switches to the Spotify app** and back; the OS does not
-   *   allow waking another app without a foreground app-switch.
-   * - Requires Spotify Premium for on-demand playback of a specific `uri`.
-   *
-   * @param accessToken Access token from `Auth.authenticate()`. On Android this
-   *   is an iOS-parity parameter (see {@link connect}); on iOS the token
-   *   returned by the authorization redirect is used to complete the connection.
-   * @param uri Spotify URI to play. Pass an empty string (the default) to
-   *   resume the user's last track or play a contextual/random track.
-   *
-   * Resolves once Spotify is connected and the play command has been issued;
-   * rejects with an {@link AppRemoteError} if Spotify is not installed or the
-   * authorization is denied.
+   * @param accessToken Access token from `Auth.authenticate()`.
+   * @param uri Spotify URI to play, or empty (default) to resume last/contextual track.
    */
   authorizeAndPlay(accessToken: string, uri: string = ""): Promise<void> {
     return ExpoSpotifySDKModule.appRemoteAuthorizeAndPlay(


### PR DESCRIPTION
## Summary
- Extract iOS App Remote connection lifecycle (connect, authorize-and-play, redirect) from the coordinator into dedicated files
- Deduplicate `connect` / `authorizeAndPlay` bootstrap via `beginConnection`
- Replace `pendingAuthorizeRemote` with a unified `connectionAttempt` model
- Share main-thread redirect hop with `SpotifyAuthCoordinator` via `SpotifyMainThread`
- Trim duplicate `authorizeAndPlay` JSDoc; update error-codes recovery hint

Follow-up internal refactor to #54 — no public API changes.

## Test plan
- [x] `yarn test`
- [ ] iOS: `connect` with Spotify foreground
- [ ] iOS: `authorizeAndPlay` with Spotify suspended
- [ ] iOS: auth redirect still works after app-remote redirect ordering
- [ ] Android: `authorizeAndPlay` smoke test


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `authorizeAndPlay()` now recovers when Spotify is suspended on iOS.

* **Documentation**
  * Updated error recovery guidance for `CONNECTION_FAILED` scenarios.
  * Streamlined method documentation for clarity.

* **Tests**
  * Added test coverage for Spotify suspension recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->