### PR TITLE
fix(android): drop explicit Ant download timeouts for Spotify AAR fetch

### DIFF
--- a/android/spotify-native-sdk.gradle
+++ b/android/spotify-native-sdk.gradle
@@ -71,9 +71,7 @@ tasks.register("downloadSpotifyAppRemoteAar") {
       ant.get(
         src: downloadUrl,
         dest: tmp,
-        verbose: true,
-        connecttimeout: 30000,
-        readtimeout: 60000
+        verbose: true
       )
       def actual = sha256File(tmp)
       if (actual != appRemoteSha256) {


### PR DESCRIPTION
## Summary
- Remove hard-coded `connecttimeout` and `readtimeout` from the Spotify App Remote AAR download task in `android/spotify-native-sdk.gradle`
- Let Ant `get` use its default timeouts so slower networks are less likely to fail mid-download

## Test plan
- [ ] Run an Android prebuild/build that triggers `downloadSpotifyAppRemoteAar` on a clean `libs/` directory
- [ ] Confirm the AAR downloads successfully and checksum validation still passes


Made with [Cursor](https://cursor.com)