### PR TITLE
fix(ios): fetch SpotifyiOS via CocoaPods binary pod at pod install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,6 @@ jobs:
       - name: Build plugin
         run: yarn build:plugin
 
+      - name: Verify npm pack layout
+        run: bash scripts/verify-npm-pack.sh
+

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ yarn-error.log
 
 # npm pack dry-run artifacts (repo root)
 /wwdrew-expo-spotify-sdk-*.tgz
+
+# CocoaPods binary pod prepare_command output (local pod install only)
+spotify-ios/SpotifyiOS.xcframework/
+spotify-ios/Licenses/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ yarn test
 
 ### Spotify native SDK binaries
 
-Spotify native binaries are **not** committed to git or bundled in npm. They are resolved at native build time — iOS via SPM at `pod install`, Android via Gradle download at build ([ADR-0008](./docs/adr/0008-ios-spotify-sdk-via-spm.md)).
+Spotify native binaries are **not** committed to git or bundled in npm. They are resolved at native build time — iOS via CocoaPods HTTP binary pod at `pod install`, Android via Gradle download at build ([ADR-0009](./docs/adr/0009-ios-spotify-sdk-via-cocoapods-binary-pod.md)).
 
 Full details: [docs/guides/native-sdk-distribution.md](./docs/guides/native-sdk-distribution.md).
 
@@ -77,7 +77,7 @@ We keep `expo-module-scripts` for shared config (`tsconfig`, ESLint presets) but
 
 ### iOS native (`ios/`)
 
-Requires network for `pod install` (SPM resolves `SpotifyiOS` from GitHub).
+Requires network for `pod install` (CocoaPods downloads `SpotifyiOS` from GitHub).
 
 ```sh
 cd example/ios && pod install && cd ..

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For bare React Native (no Expo CLI), see [Installation in bare React Native](#in
 
 | Platform | Distribution |
 | --- | --- |
-| **iOS** | `SpotifyiOS` resolved from Spotify's GitHub via SPM at `pod install` ([ADR-0008](./docs/adr/0008-ios-spotify-sdk-via-spm.md)). Uses React Native's `spm_dependency` (RN 0.75+). Supported Expo SDK lanes: [Platform support](#platform-support). |
+| **iOS** | `SpotifyiOS` downloaded via CocoaPods HTTP binary pod at `pod install` ([ADR-0009](./docs/adr/0009-ios-spotify-sdk-via-cocoapods-binary-pod.md)). Config plugin injects the Podfile `pod` line on `expo prebuild`. Supported Expo SDK lanes: [Platform support](#platform-support). |
 | **Android** | App Remote AAR downloaded from Spotify's GitHub at Gradle build. Auth SDK from Maven Central. |
 
 | You are… | Action |
@@ -127,10 +127,11 @@ yarn add @wwdrew/expo-spotify-sdk expo-modules-core
 
 ### 2. iOS
 
-Add the pod to your `Podfile`:
+Add pods to your `Podfile`:
 
 ```ruby
 pod 'ExpoSpotifySDK', :path => '../node_modules/@wwdrew/expo-spotify-sdk'
+pod 'SpotifyiOS', :podspec => File.join(__dir__, '../node_modules/@wwdrew/expo-spotify-sdk/spotify-ios/SpotifyiOS.podspec')
 ```
 
 Then install pods:

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -25,7 +25,7 @@ cd example && yarn install && cd ..
 npx expo prebuild
 ```
 
-When QAing a **published npm version** (not a git checkout), install from npm — native SDKs resolve at build time (SPM / Gradle).
+When QAing a **published npm version** (not a git checkout), install from npm — native SDKs resolve at build time (CocoaPods / Gradle).
 
 On **`main`**, you can also exercise the **typed config plugin** in `app.config.ts` (`import { withSpotifySdk } from "@wwdrew/expo-spotify-sdk/plugin"`). That path is not on `v1`.
 

--- a/docs/adr/0008-ios-spotify-sdk-via-spm.md
+++ b/docs/adr/0008-ios-spotify-sdk-via-spm.md
@@ -1,6 +1,6 @@
 # ADR-0008: Native Spotify SDKs resolved at build time
 
-- **Status:** Accepted
+- **Status:** Accepted (iOS portion superseded by [ADR-0009](./0009-ios-spotify-sdk-via-cocoapods-binary-pod.md))
 - **Date:** 2026-06-06
 - **Deciders:** @wwdrew
 - **Supersedes:** [ADR-0001](./0001-build-time-download-of-spotify-native-sdks.md) (both platforms)

--- a/docs/adr/0009-ios-spotify-sdk-via-cocoapods-binary-pod.md
+++ b/docs/adr/0009-ios-spotify-sdk-via-cocoapods-binary-pod.md
@@ -1,0 +1,77 @@
+# ADR-0009: iOS Spotify SDK via CocoaPods binary pod (HTTP download at pod install)
+
+- **Status:** Proposed
+- **Date:** 2026-06-08
+- **Deciders:** @wwdrew
+- **Supersedes:** iOS portion of [ADR-0008](./0008-ios-spotify-sdk-via-spm.md)
+
+## Context
+
+ADR-0008 resolved `SpotifyiOS` via SPM (`spm_dependency`) at `pod install`. That fails in real apps using `ios.useFrameworks: "static"` with static Expo modules — SPM and vendored static pods do not compose reliably.
+
+ADR-0001 bundled the xcframework in npm. That works but re-distributes Spotify binaries (~1 MB tarball bloat) and is legally grey vs Developer Terms.
+
+We need iOS to:
+
+1. **Not use SPM**
+2. **Not bundle Spotify code in npm**
+3. **Work with static CocoaPods frameworks**
+4. **Mirror Android** (fetch at app native build setup, pinned version)
+
+### Why not `prepare_command` on the Expo module podspec?
+
+CocoaPods **does not run `prepare_command` for `:path` pods** — and Expo autolinking always uses `:path` to `node_modules/@wwdrew/expo-spotify-sdk/ios`.
+
+### Why a separate `SpotifyiOS` pod with `:podspec`?
+
+A dedicated `spotify-ios/SpotifyiOS.podspec` referenced from the app Podfile via `:podspec` (not `:path`) uses `source: { http: ... }`. CocoaPods then downloads the Spotify GitHub release tarball and runs `prepare_command` to extract `SpotifyiOS.xcframework`.
+
+`expo-module.config.json` sets `"podspecPath": "ios/ExpoSpotifySDK.podspec"` so autolinking does not also pick up `SpotifyiOS.podspec` as a duplicate `:path` pod.
+
+## Decision
+
+**iOS:** Config plugin injects `pod 'SpotifyiOS', :podspec => ...` into the app Podfile. `ExpoSpotifySDK` depends on `SpotifyiOS`. No SPM.
+
+**Android:** unchanged — Gradle `preBuild` download ([ADR-0001](./0001-build-time-download-of-spotify-native-sdks.md)).
+
+### iOS components
+
+| Piece | Role |
+| --- | --- |
+| `spotify-ios/SpotifyiOS.podspec` | HTTP binary pod; `prepare_command` extracts `SpotifyiOS.xcframework` |
+| `ios/spotify-native-sdk-versions.json` | Pin `version` (and checksums for maintainer reference) |
+| `plugin/.../withSpotifyIosPod.ts` | Injects tagged `pod` line after `use_expo_modules!` |
+| `expo-module.config.json` | `podspecPath` limits autolinking to `ExpoSpotifySDK` only |
+| `ios/ExpoSpotifySDK.podspec` | `s.dependency 'SpotifyiOS'` (no `spm_dependency`, no vendored xcframework) |
+
+### Bare React Native
+
+Consumers without the config plugin must add the same `pod` line to their Podfile (see README bare-install section).
+
+## Consequences
+
+### Positive
+
+- Zero Spotify binaries in npm
+- Works with `static_framework = true` and `ios.useFrameworks: "static"`
+- Standard CocoaPods binary pod pattern (no `pre_install` bash hooks)
+- Symmetric with Android build-time fetch model
+
+### Negative
+
+- Network required on first iOS `pod install` per machine
+- Bare apps without the config plugin need the Podfile `pod` line manually
+- Two pod targets (`SpotifyiOS` + `ExpoSpotifySDK`) instead of one SPM product
+
+### Neutral
+
+- Downloaded xcframework cached under CocoaPods `Pods/` (not in git or npm)
+- `scripts/verify-npm-pack.sh` asserts tarball shape at publish time
+
+## Validation
+
+1. `bash scripts/verify-npm-pack.sh` — tarball contains podspec, not xcframework
+2. `npx expo prebuild --clean` in example → Podfile contains tagged `pod 'SpotifyiOS'`
+3. `cd example/ios && pod install` → `[CP] Copy XCFrameworks` for SpotifyiOS
+4. `xcodebuild` simulator build succeeds
+5. Consumer app with `ios.useFrameworks: "static"` builds without SPM

--- a/docs/guides/native-sdk-distribution.md
+++ b/docs/guides/native-sdk-distribution.md
@@ -2,23 +2,23 @@
 
 How Spotify's iOS and Android SDK binaries reach consumers of `@wwdrew/expo-spotify-sdk`.
 
-See [ADR-0008](../adr/0008-ios-spotify-sdk-via-spm.md) (supersedes [ADR-0001](../adr/0001-build-time-download-of-spotify-native-sdks.md)).
+See [ADR-0009](../adr/0009-ios-spotify-sdk-via-cocoapods-binary-pod.md) (iOS) and [ADR-0001](../adr/0001-build-time-download-of-spotify-native-sdks.md) (Android). ADR-0009 supersedes the iOS portion of [ADR-0008](../adr/0008-ios-spotify-sdk-via-spm.md).
 
 ## Summary
 
 | Audience | What happens |
 | --- | --- |
 | **npm consumers** | `npm install` — no Spotify binaries in the tarball. Native SDKs resolved at build time. |
-| **npm consumers (iOS)** | `pod install` resolves `SpotifyiOS` from Spotify's GitHub via SPM. Network required on first iOS native build. |
+| **npm consumers (iOS)** | `pod install` downloads `SpotifyiOS` via CocoaPods HTTP binary pod (`spotify-ios/SpotifyiOS.podspec`). Network required on first iOS native build. |
 | **npm consumers (Android)** | Gradle `preBuild` downloads App Remote AAR from Spotify's GitHub. Network required on first Android native build. |
 | **git contributors** | Same as npm consumers — no manual fetch scripts. |
-| **release CI** | `prepublishOnly` runs `yarn build` and `yarn build:plugin`. |
+| **release CI** | `prepublishOnly` runs `yarn build`, `yarn build:plugin`, and `scripts/verify-npm-pack.sh`. |
 
 ## What is bundled / resolved
 
 | Platform | Artifact | How it arrives |
 | --- | --- | --- |
-| iOS | `SpotifyiOS` (SPM) | `spm_dependency` → [spotify/ios-sdk](https://github.com/spotify/ios-sdk) at `pod install` |
+| iOS | `SpotifyiOS.xcframework` | Config plugin adds `pod 'SpotifyiOS', :podspec => ...` → HTTP download at `pod install` → [spotify/ios-sdk](https://github.com/spotify/ios-sdk) |
 | Android (App Remote) | `spotify-app-remote-release-<version>.aar` | Gradle download at build → [spotify/android-sdk releases](https://github.com/spotify/android-sdk/releases) |
 | Android (Auth) | `com.spotify.android:auth` | Maven Central (version in `android/build.gradle`) |
 
@@ -31,9 +31,10 @@ Version pins: [`ios/spotify-native-sdk-versions.json`](../ios/spotify-native-sdk
 `package.json` `files` includes:
 
 - `ios/spotify-native-sdk-versions.json`
+- `spotify-ios/SpotifyiOS.podspec`
 - `android/spotify-native-sdk.gradle`
 
-No Spotify native binaries are listed in `files`.
+No Spotify native binaries are listed in `files`. `scripts/verify-npm-pack.sh` enforces this at publish time.
 
 ## Local development workflow
 
@@ -45,9 +46,10 @@ cd example
 # Android — Gradle downloads AAR on first build (network required)
 npx expo run:android
 
-# iOS — SPM fetch at pod install (network required)
+# iOS — CocoaPods downloads xcframework at pod install (network required)
+npx expo prebuild --clean
 cd ios && pod install && cd ..
-# xcodebuild …  (see ADR-0008 validation) — avoids starting Metro via expo run:ios
+# xcodebuild …  (see ADR-0009 validation) — avoids starting Metro via expo run:ios
 ```
 
 Plugin-only work (`yarn test`, `yarn lint`, `yarn typecheck`) does not need native builds.
@@ -55,10 +57,8 @@ Plugin-only work (`yarn test`, `yarn lint`, `yarn typecheck`) does not need nati
 ## Bumping Spotify SDK versions
 
 1. Update `ios/spotify-native-sdk-versions.json`:
-   - **iOS:** `spmVersion` (and repo URL/product if needed).
+   - **iOS:** `version`, `tarballSha256`, `binarySha256`.
    - **Android:** `appRemoteVersion`, `appRemoteReleaseTag`, `appRemoteSha256`.
 2. Ship a new `@wwdrew/expo-spotify-sdk` release.
 
-## Cherry-pick to `v1`
-
-See [ADR-0008 § Cherry-pick to v1](../adr/0008-ios-spotify-sdk-via-spm.md#cherry-pick-to-v1-sdk-55-lane).
+For the SDK 55 lane, see [ADR-0008 § Cherry-pick to v1](../adr/0008-ios-spotify-sdk-via-spm.md#cherry-pick-to-v1-sdk-55-lane).

--- a/example/ios/.gitignore
+++ b/example/ios/.gitignore
@@ -28,6 +28,3 @@ project.xcworkspace
 
 # CocoaPods
 /Pods/
-
-# Swift Package Manager (SpotifyiOS via ExpoSpotifySDK pod; regenerated at pod install)
-*.xcworkspace/xcshareddata/swiftpm/

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -25,6 +25,9 @@ prepare_react_native_project!
 
 target 'expospotifysdkexample' do
   use_expo_modules!
+# @generated begin expo-spotify-sdk-spotify-ios-pod - expo prebuild (DO NOT MODIFY) sync-af4a1e8fbb8224754de20fa24160561ed6411cc0
+  pod 'SpotifyiOS', :podspec => File.join(__dir__, '../node_modules/@wwdrew/expo-spotify-sdk/spotify-ios/SpotifyiOS.podspec')
+# @generated end expo-spotify-sdk-spotify-ios-pod
 
   if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'
     config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - EXConstants (56.0.16):
+  - EXConstants (56.0.17):
     - ExpoModulesCore
-  - Expo (56.0.6):
+  - Expo (56.0.9):
     - ExpoModulesCore
     - ExpoModulesJSI
     - hermes-engine
@@ -27,7 +27,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoAsset (56.0.15):
+  - ExpoAsset (56.0.16):
     - ExpoModulesCore
   - ExpoDomWebView (56.0.5):
     - ExpoModulesCore
@@ -39,11 +39,11 @@ PODS:
     - ExpoModulesCore
   - ExpoKeepAwake (56.0.3):
     - ExpoModulesCore
-  - ExpoLinking (56.0.12):
+  - ExpoLinking (56.0.13):
     - ExpoModulesCore
   - ExpoLogBox (56.0.12):
     - React-Core
-  - ExpoModulesCore (56.0.13):
+  - ExpoModulesCore (56.0.15):
     - ExpoModulesJSI
     - hermes-engine
     - RCTRequired
@@ -67,24 +67,25 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoModulesJSI (56.0.7):
+  - ExpoModulesJSI (56.0.8):
     - React-Core
     - ReactCommon
-  - ExpoModulesWorklets (56.0.13):
+  - ExpoModulesWorklets (56.0.15):
     - ExpoModulesCore
     - ExpoModulesJSI
-  - ExpoRouter (56.2.7):
+  - ExpoRouter (56.2.9):
     - ExpoModulesCore
     - RNScreens
   - ExpoSplashScreen (56.0.10):
     - ExpoModulesCore
-  - ExpoSpotifySDK (2.0.0):
+  - ExpoSpotifySDK (2.2.1):
     - ExpoModulesCore
-  - ExpoSymbols (56.0.5):
+    - SpotifyiOS
+  - ExpoSymbols (56.0.6):
     - ExpoModulesCore
   - ExpoSystemUI (56.0.5):
     - ExpoModulesCore
-  - ExpoUI (56.0.14):
+  - ExpoUI (56.0.16):
     - ExpoModulesCore
     - ExpoModulesWorklets
     - React-RCTFabric
@@ -2058,6 +2059,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
+  - SpotifyiOS (5.0.1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2159,6 +2161,7 @@ DEPENDENCIES:
   - "RNCMaskedView (from `../node_modules/@react-native-masked-view/masked-view`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - "SpotifyiOS (from `/Users/drew/Projects/wwdrew/expo-spotify-sdk/example/ios/../node_modules/@wwdrew/expo-spotify-sdk/spotify-ios/SpotifyiOS.podspec`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 EXTERNAL SOURCES:
@@ -2357,29 +2360,31 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-gesture-handler"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  SpotifyiOS:
+    :podspec: "/Users/drew/Projects/wwdrew/expo-spotify-sdk/example/ios/../node_modules/@wwdrew/expo-spotify-sdk/spotify-ios/SpotifyiOS.podspec"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EXConstants: 1c400bb9969f4c9e5ab324553138b74ae47b9efe
-  Expo: 61fe266f060d8182c41710ab34b9cc50a625ff7d
-  ExpoAsset: c2e7b5ba1fe75be683282d6264e38fd7cd8defbb
+  EXConstants: 659c2e5593243436fd8ed4ba6225d2ebd045d84a
+  Expo: 9ca20ca4a888b3de7c1a99f93e094c486dfe5b36
+  ExpoAsset: c3045ed094105f5f2bf332e36ef1bd63401c948f
   ExpoDomWebView: 27205be8754f9992913b8a9a08e65019f2207075
   ExpoFileSystem: d730a1cb33f2c91dec01561f0d710054fda32ae9
   ExpoFont: 6fe496f2be617ed4367f159f215dcc4ba27d37d6
   ExpoGlassEffect: 7d4233dc0727ee2b28dd757eda70e1b6abf662fd
   ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
-  ExpoLinking: 82458b046854a5802092a37a5228a8a228f928a4
+  ExpoLinking: 49cc5ddd93b68506c588aa1985c27b795e6d69d6
   ExpoLogBox: 7aa03244fe5eeced5129e4ec7ad5bd9a3994378e
-  ExpoModulesCore: ca7943675f6b2e6f8bf8db40af03e2fc42190849
-  ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
-  ExpoModulesWorklets: c755176116ae553ede2268ca6837c31eb4081f8a
-  ExpoRouter: 06524ed53f9833aabf49053a119bcc92c1442098
+  ExpoModulesCore: f2fdf86ead80871a18141215332bc8fa41d131be
+  ExpoModulesJSI: 8028268310770bed2f3f3aec6e7bf150714841b1
+  ExpoModulesWorklets: 3a5a7126f22ccacf3189bdf0be37022efd5e4578
+  ExpoRouter: ed3d4e1815fd19856f3a7fbc68ad8565d9eb355d
   ExpoSplashScreen: 3fe3a57d56d7242a9109d9714a6f9fa1e256538b
-  ExpoSpotifySDK: 18398cd40e5b252f7b0eeb0896ae1df21741eda7
-  ExpoSymbols: f83c91f2897d37102b98b9224c603095630be9d0
+  ExpoSpotifySDK: 2bbc476c413fe29935c4f9429220d9cc7dbb0f6c
+  ExpoSymbols: 377747de25bcb1ab68ec68f23d81fb81d43eae83
   ExpoSystemUI: 8f4fb641c6a6ebe2a01dda0fbd3fdd952ab5823a
-  ExpoUI: 649b8cbcccd23277afa83bf0d065bc40906b7e3a
+  ExpoUI: 87bfd96f91fce59e1cfc1ed166dd7a6331aff2f9
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
   hermes-engine: be8becc61750fae2926e4f9b78044964b1f845df
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
@@ -2458,8 +2463,9 @@ SPEC CHECKSUMS:
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: 2ff61eac036eaf89f6818bf4ed9c39771a17d134
   RNScreens: f94000b3cb1eb14cbb8d08dd6074fdd6ccf0e6b0
+  SpotifyiOS: 8655858a3bb2d22d823a0937ba420bb87c63997f
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 
-PODFILE CHECKSUM: d1296fb07778727eeb46640b8c5b37fcc1be67c7
+PODFILE CHECKSUM: 9557e6f25755f5be2308e96e8676dd1f216712ea
 
 COCOAPODS: 1.16.2

--- a/example/ios/expospotifysdkexample.xcodeproj/project.pbxproj
+++ b/example/ios/expospotifysdkexample.xcodeproj/project.pbxproj
@@ -7,27 +7,27 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		08AD0D4552C4BF4D91A0EBF6 /* libPods-expospotifysdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AE980BFFC7F18E20DDF080AE /* libPods-expospotifysdkexample.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
-		1C67E654465B080388317B0F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6F2A5FB19BB799D39DA5817B /* PrivacyInfo.xcprivacy */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		81B50DC5FBDCF53942B7AF85 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866744437230D86CA4A2AB7E /* ExpoModulesProvider.swift */; };
-		87BD192EFC298078782E4723 /* libPods-expospotifysdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 013A8A0F8C89CC2D19A3EEC7 /* libPods-expospotifysdkexample.a */; };
+		58811139EB6D2E8C75A68BE2 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = EE2C6A95E56021BC75EB1D92 /* PrivacyInfo.xcprivacy */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+		E9F9D71CB6580E3B6E679451 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E757DB5DD907BBE0AF2A7E /* ExpoModulesProvider.swift */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		013A8A0F8C89CC2D19A3EEC7 /* libPods-expospotifysdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-expospotifysdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		039F4E8A0D09998C75D341F9 /* Pods-expospotifysdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expospotifysdkexample.debug.xcconfig"; path = "Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* expospotifysdkexample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = expospotifysdkexample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = expospotifysdkexample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = expospotifysdkexample/Info.plist; sourceTree = "<group>"; };
-		4ABA610B6C734452DE925A65 /* Pods-expospotifysdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expospotifysdkexample.debug.xcconfig"; path = "Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample.debug.xcconfig"; sourceTree = "<group>"; };
-		6F2A5FB19BB799D39DA5817B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = expospotifysdkexample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		866744437230D86CA4A2AB7E /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-expospotifysdkexample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = expospotifysdkexample/SplashScreen.storyboard; sourceTree = "<group>"; };
+		AE980BFFC7F18E20DDF080AE /* libPods-expospotifysdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-expospotifysdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		C8D561E67DF231DFBD70BABF /* Pods-expospotifysdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expospotifysdkexample.release.xcconfig"; path = "Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample.release.xcconfig"; sourceTree = "<group>"; };
+		D10B9A2863C2CBF2FDCFAB7D /* Pods-expospotifysdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expospotifysdkexample.release.xcconfig"; path = "Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample.release.xcconfig"; sourceTree = "<group>"; };
+		D3E757DB5DD907BBE0AF2A7E /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-expospotifysdkexample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		EE2C6A95E56021BC75EB1D92 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = expospotifysdkexample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = expospotifysdkexample/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* expospotifysdkexample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "expospotifysdkexample-Bridging-Header.h"; path = "expospotifysdkexample/expospotifysdkexample-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -37,21 +37,19 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				87BD192EFC298078782E4723 /* libPods-expospotifysdkexample.a in Frameworks */,
+				08AD0D4552C4BF4D91A0EBF6 /* libPods-expospotifysdkexample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		07F29EF857F73888E91B49E7 /* Pods */ = {
+		03CBFAD1F163738719A27379 /* expospotifysdkexample */ = {
 			isa = PBXGroup;
 			children = (
-				4ABA610B6C734452DE925A65 /* Pods-expospotifysdkexample.debug.xcconfig */,
-				C8D561E67DF231DFBD70BABF /* Pods-expospotifysdkexample.release.xcconfig */,
+				D3E757DB5DD907BBE0AF2A7E /* ExpoModulesProvider.swift */,
 			);
-			name = Pods;
-			path = Pods;
+			name = expospotifysdkexample;
 			sourceTree = "<group>";
 		};
 		13B07FAE1A68108700A75B9A /* expospotifysdkexample */ = {
@@ -63,15 +61,7 @@
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				6F2A5FB19BB799D39DA5817B /* PrivacyInfo.xcprivacy */,
-			);
-			name = expospotifysdkexample;
-			sourceTree = "<group>";
-		};
-		1C1867C800F474DD04544E94 /* expospotifysdkexample */ = {
-			isa = PBXGroup;
-			children = (
-				866744437230D86CA4A2AB7E /* ExpoModulesProvider.swift */,
+				EE2C6A95E56021BC75EB1D92 /* PrivacyInfo.xcprivacy */,
 			);
 			name = expospotifysdkexample;
 			sourceTree = "<group>";
@@ -80,7 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				013A8A0F8C89CC2D19A3EEC7 /* libPods-expospotifysdkexample.a */,
+				AE980BFFC7F18E20DDF080AE /* libPods-expospotifysdkexample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -99,8 +89,8 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				07F29EF857F73888E91B49E7 /* Pods */,
-				CE19F1FDBC40B23AA1F477F0 /* ExpoModulesProviders */,
+				B6D53E936ACAE7908BBE55D7 /* Pods */,
+				D2005FFF7582F52DC8CA6747 /* ExpoModulesProviders */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -115,6 +105,16 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		B6D53E936ACAE7908BBE55D7 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				039F4E8A0D09998C75D341F9 /* Pods-expospotifysdkexample.debug.xcconfig */,
+				D10B9A2863C2CBF2FDCFAB7D /* Pods-expospotifysdkexample.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		BB2F792B24A3F905000567C9 /* Supporting */ = {
 			isa = PBXGroup;
 			children = (
@@ -124,10 +124,10 @@
 			path = expospotifysdkexample/Supporting;
 			sourceTree = "<group>";
 		};
-		CE19F1FDBC40B23AA1F477F0 /* ExpoModulesProviders */ = {
+		D2005FFF7582F52DC8CA6747 /* ExpoModulesProviders */ = {
 			isa = PBXGroup;
 			children = (
-				1C1867C800F474DD04544E94 /* expospotifysdkexample */,
+				03CBFAD1F163738719A27379 /* expospotifysdkexample */,
 			);
 			name = ExpoModulesProviders;
 			sourceTree = "<group>";
@@ -140,13 +140,13 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "expospotifysdkexample" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				8896EC1D50B426B7A52EF3BE /* [Expo] Configure project */,
+				AD4F90E145248D1BE1A25362 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				C35D565BD223C1926C3B9623 /* [CP] Embed Pods Frameworks */,
+				DF35EEE36E07F5E4006DC321 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -196,7 +196,7 @@
 				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
-				1C67E654465B080388317B0F /* PrivacyInfo.xcprivacy in Resources */,
+				58811139EB6D2E8C75A68BE2 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -272,7 +272,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8896EC1D50B426B7A52EF3BE /* [Expo] Configure project */ = {
+		AD4F90E145248D1BE1A25362 /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -296,7 +296,7 @@
 			shellPath = /bin/sh;
 			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-expospotifysdkexample/expo-configure-project.sh\"\n";
 		};
-		C35D565BD223C1926C3B9623 /* [CP] Embed Pods Frameworks */ = {
+		DF35EEE36E07F5E4006DC321 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -308,9 +308,9 @@
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoModulesCore/ExpoModulesCore.framework/ExpoModulesCore",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoModulesJSI/ExpoModulesJSI.framework/ExpoModulesJSI",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoModulesWorklets/ExpoModulesWorklets.framework/ExpoModulesWorklets",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoSpotifySDK/SpotifyiOS.framework/SpotifyiOS",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/React-Core-prebuilt/React.framework/React",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ReactNativeDependencies/ReactNativeDependencies.framework/ReactNativeDependencies",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/SpotifyiOS/SpotifyiOS.framework/SpotifyiOS",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermesvm.framework/hermesvm",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -320,9 +320,9 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ExpoModulesCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ExpoModulesJSI.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ExpoModulesWorklets.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SpotifyiOS.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactNativeDependencies.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SpotifyiOS.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermesvm.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -338,7 +338,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
-				81B50DC5FBDCF53942B7AF85 /* ExpoModulesProvider.swift in Sources */,
+				E9F9D71CB6580E3B6E679451 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -347,7 +347,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4ABA610B6C734452DE925A65 /* Pods-expospotifysdkexample.debug.xcconfig */;
+			baseConfigurationReference = 039F4E8A0D09998C75D341F9 /* Pods-expospotifysdkexample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -384,7 +384,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C8D561E67DF231DFBD70BABF /* Pods-expospotifysdkexample.release.xcconfig */;
+			baseConfigurationReference = D10B9A2863C2CBF2FDCFAB7D /* Pods-expospotifysdkexample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -569,10 +569,10 @@
   resolved "https://registry.yarnpkg.com/@expo-google-fonts/material-symbols/-/material-symbols-0.4.38.tgz#88982312fb1a2ff18cd002874aaa9bbee0157727"
   integrity sha512-IJkBtN1o8u9BW5fvSii1MyHPQ7Q0HxbWcVBvOrOzgMLpVtZw7R2w94wBTVR7kZwv3w1JNTESMmLA5Sqn1+Z36A==
 
-"@expo/cli@^56.1.13":
-  version "56.1.13"
-  resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-56.1.13.tgz#887f549c6e1624cce64473d6151cf025e3572866"
-  integrity sha512-7n5VzlBr7TKW0BgWgpEopWy+v8buPhMvbSEsuXD+bI1YIJBopkfWAub0qTvlc357E8wWOvV5MJXYyoeRvoOjoQ==
+"@expo/cli@^56.1.14":
+  version "56.1.14"
+  resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-56.1.14.tgz#f999727e65a6f85e47c5476e865a43deb71aa9ad"
+  integrity sha512-rSH3ygjEPipEYG6dgiJ116J8KqCQ/BYKcwQDipStSh4IFWJ10RZaYP4u5B74jxfeIWjWrOeqvwB6NZfQBjaQ4Q==
   dependencies:
     "@expo/code-signing-certificates" "^0.0.6"
     "@expo/config" "~56.0.9"
@@ -580,7 +580,7 @@
     "@expo/devcert" "^1.2.1"
     "@expo/env" "~2.3.0"
     "@expo/image-utils" "^0.10.1"
-    "@expo/inline-modules" "^0.0.10"
+    "@expo/inline-modules" "^0.0.11"
     "@expo/json-file" "^10.2.0"
     "@expo/log-box" "^56.0.12"
     "@expo/metro" "~56.0.0"
@@ -589,9 +589,9 @@
     "@expo/osascript" "^2.6.0"
     "@expo/package-manager" "^1.12.1"
     "@expo/plist" "^0.7.0"
-    "@expo/prebuild-config" "^56.0.14"
+    "@expo/prebuild-config" "^56.0.15"
     "@expo/require-utils" "^56.1.3"
-    "@expo/router-server" "^56.0.12"
+    "@expo/router-server" "^56.0.13"
     "@expo/schema-utils" "^56.0.0"
     "@expo/spawn-async" "^1.8.0"
     "@expo/ws-tunnel" "^1.0.1"
@@ -607,7 +607,7 @@
     connect "^3.7.0"
     debug "^4.3.4"
     dnssd-advertise "^1.1.4"
-    expo-server "^56.0.4"
+    expo-server "^56.0.5"
     fetch-nodeshim "^0.4.10"
     getenv "^2.0.0"
     glob "^13.0.0"
@@ -713,10 +713,10 @@
   resolved "https://registry.yarnpkg.com/@expo/expo-modules-macros-plugin/-/expo-modules-macros-plugin-0.0.9.tgz#a657f9c3c2dbf1c91bae7ef47238078995cd1bc4"
   integrity sha512-odai6D7ng/gA7At8ukFcWcauNEeDdyVqzVPbQxDkyU2NTJ4kgphA4I5iigS5C4LXFicSIzEt2nzdlLM8sjsTdA==
 
-"@expo/fingerprint@^0.19.3":
-  version "0.19.3"
-  resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.19.3.tgz#5fcf25adba9fd4cefd6f0e251849136a83fce3e2"
-  integrity sha512-w9Au2IVrtc0Ct+WRa05DVHGNHXYq6VyPZWuFP+5x055OeZ5q6k5Yg+aJ1gfShmjdOhDftRcsvmWmTdTZlWaTZw==
+"@expo/fingerprint@^0.19.4":
+  version "0.19.4"
+  resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.19.4.tgz#5c78b8cfce8af1e039be2bdccd8c0f058cad26a6"
+  integrity sha512-PsowRlO8+S7JlO8go7yhNEXp7sqlsWDE2AlCwoss7zH0dcajXFo74Fy0KdXEc4UXK7kKoHD37oDgsZ8aHSLr7A==
   dependencies:
     "@expo/env" "^2.3.0"
     "@expo/spawn-async" "^1.8.0"
@@ -743,10 +743,10 @@
     parse-png "^2.1.0"
     semver "^7.6.0"
 
-"@expo/inline-modules@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@expo/inline-modules/-/inline-modules-0.0.10.tgz#9d22dfebbb08d9c40b51b0f54729e327844525d7"
-  integrity sha512-DKEfq877UTAmL/gOT5aFhlLNDg/EVmTSca7JQMKDGR6mjFSAcrmQf4GJNsi6ztiaqj6cTnIfoSz0hAYdnr6RJQ==
+"@expo/inline-modules@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@expo/inline-modules/-/inline-modules-0.0.11.tgz#d780b808937da377aa0125341a782f26bd6f7381"
+  integrity sha512-ZlIfKL61DPnW8YUTdMEjMA31xrDDV6p7Xi8rWYyhd5qXBV8MwGwjuJ7vKeaVaMjRqxJk1N9lv7zlfyvQpRCNNw==
   dependencies:
     "@expo/config-plugins" "~56.0.8"
 
@@ -817,10 +817,10 @@
     micromatch "^4.0.4"
     walker "^1.0.8"
 
-"@expo/metro-runtime@^56.0.13":
-  version "56.0.13"
-  resolved "https://registry.yarnpkg.com/@expo/metro-runtime/-/metro-runtime-56.0.13.tgz#95b66e4a527a8f9aac3d807bae8f3ec185df7341"
-  integrity sha512-aMaFa/RPYm2iQoyYOB5q8AxDmWvf4E2yFbZ6rmBIQWaIPDdixGVUlLQeV8DlDAfZ/j+pNYO7l5M+774WbgkTgg==
+"@expo/metro-runtime@^56.0.14":
+  version "56.0.14"
+  resolved "https://registry.yarnpkg.com/@expo/metro-runtime/-/metro-runtime-56.0.14.tgz#dd7bba9fc41e3b7ca1b3211145c753ee34c45e31"
+  integrity sha512-xqSWX7W1jd/B8MzDOJkc/iHAtIsHOMYrDya/jJkEj8A6XdN4XqtmxqfAQ2oWcpYi47vH97lECDp8aoP7jO6v0Q==
   dependencies:
     "@expo/log-box" "^56.0.12"
     anser "^1.4.9"
@@ -876,10 +876,10 @@
     base64-js "^1.5.1"
     xmlbuilder "^15.1.1"
 
-"@expo/prebuild-config@^56.0.14":
-  version "56.0.14"
-  resolved "https://registry.yarnpkg.com/@expo/prebuild-config/-/prebuild-config-56.0.14.tgz#aa0159bbe6229e087dee2934dece02d18b4aa089"
-  integrity sha512-JHdMqR7Mf5ApLC50ZwTL0Z86ezrHOMYwoSHcWT6Pha/+1TcC+/J+i7vjhP06wGXQ2Kvjt74p/3mKg2Pd12KjhQ==
+"@expo/prebuild-config@^56.0.15":
+  version "56.0.15"
+  resolved "https://registry.yarnpkg.com/@expo/prebuild-config/-/prebuild-config-56.0.15.tgz#a16601e67892e7e7859f30e0629a1f37b5a7794e"
+  integrity sha512-6GC+QjdCkzp/5wjsqgfu/B2+2yf5MyZMtzf9szIPrLt9uKhzV2PdyM0vU0kvbj1YT8weHCtO7bsrzimman0sjA==
   dependencies:
     "@expo/config" "~56.0.9"
     "@expo/config-plugins" "~56.0.8"
@@ -888,7 +888,7 @@
     "@expo/json-file" "^10.2.0"
     "@react-native/normalize-colors" "0.85.3"
     debug "^4.3.1"
-    expo-modules-autolinking "~56.0.14"
+    expo-modules-autolinking "~56.0.15"
     resolve-from "^5.0.0"
     semver "^7.6.0"
 
@@ -901,10 +901,10 @@
     "@babel/core" "^7.25.2"
     "@babel/plugin-transform-modules-commonjs" "^7.24.8"
 
-"@expo/router-server@^56.0.12":
-  version "56.0.12"
-  resolved "https://registry.yarnpkg.com/@expo/router-server/-/router-server-56.0.12.tgz#ecdaf80ee8e20d3a54aa9ce44068c368b3399179"
-  integrity sha512-RqKV2/Z8BH/z8l0ngSpG6//5xxJPaF5dTQvSfPQ0nrvCjikGMeIvyj3B9BeLnmZZhxb3gBtXqrj3irAoiIp2aQ==
+"@expo/router-server@^56.0.13":
+  version "56.0.13"
+  resolved "https://registry.yarnpkg.com/@expo/router-server/-/router-server-56.0.13.tgz#c74c9892d0549479a982a23923ea6655328515b7"
+  integrity sha512-M2H2zHlRBKIPENCWV8Gqo3/9WANCS9vvOMCcdWfS9wD8XXMnDASFniS0bBoGwwS1qq1LIpYzX8m8wdv7Awy88g==
   dependencies:
     debug "^4.3.4"
 
@@ -930,10 +930,10 @@
   resolved "https://registry.yarnpkg.com/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz#0fd2813402a42988e49145cab220e25bea74b308"
   integrity sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==
 
-"@expo/ui@^56.0.15":
-  version "56.0.15"
-  resolved "https://registry.yarnpkg.com/@expo/ui/-/ui-56.0.15.tgz#61cae87dc183180f2560b70169be6a45ed10d740"
-  integrity sha512-PFZBzztQGCp2bRFP8wIOb5ntP2ORH2GdQkJMSJcDOd4NldoWMe1pFqv7PdthjNlaaTHHTTHK+RsQrz+M6z6isw==
+"@expo/ui@^56.0.16":
+  version "56.0.16"
+  resolved "https://registry.yarnpkg.com/@expo/ui/-/ui-56.0.16.tgz#2b8ad51408c9ddc3a2eb8415bc6bf9a18b3a57ca"
+  integrity sha512-NPbpseOC4VNoDvOBgGtTb63fu2IfdnxNwp9K8pqU2mBTQPxEMcxF0ijgNBJ0Ze1NEuLJoBhJyrHWoj3zRmovkA==
   dependencies:
     sf-symbols-typescript "^2.1.0"
     vaul "^1.1.2"
@@ -1048,185 +1048,177 @@
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz#a1c79dcc9ae5f8c02aea8c2f144e5af6a822e5e8"
   integrity sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==
 
-"@radix-ui/primitive@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
-  integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
+"@radix-ui/primitive@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.4.tgz#47ef0f6cff4a1a1c09ebbf6d79159b7f01b967cf"
+  integrity sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==
 
-"@radix-ui/react-collection@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.7.tgz#d05c25ca9ac4695cc19ba91f42f686e3ea2d9aec"
-  integrity sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==
+"@radix-ui/react-collection@1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-collection/-/react-collection-1.1.9.tgz#09200355a16dfed0b1001e6e7a46a78dd4ebda61"
+  integrity sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==
   dependencies:
-    "@radix-ui/react-compose-refs" "1.1.2"
-    "@radix-ui/react-context" "1.1.2"
-    "@radix-ui/react-primitive" "2.1.3"
-    "@radix-ui/react-slot" "1.2.3"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.1.4"
+    "@radix-ui/react-primitive" "2.1.5"
+    "@radix-ui/react-slot" "1.2.5"
 
-"@radix-ui/react-compose-refs@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
-  integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
+"@radix-ui/react-compose-refs@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz#5f1e61e1a5f52800d31e7f8affa6d046e38f50d1"
+  integrity sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==
 
-"@radix-ui/react-context@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
-  integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
+"@radix-ui/react-context@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.4.tgz#5e39f26ebbefed27836e46e763e8f71e09999ccd"
+  integrity sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==
 
 "@radix-ui/react-dialog@^1.1.1":
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz#1de3d7a7e9a17a9874d29c07f5940a18a119b632"
-  integrity sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.16.tgz#9b28eb1cdbb412bd2b8bc4bc310feaf83e701879"
+  integrity sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==
   dependencies:
-    "@radix-ui/primitive" "1.1.3"
-    "@radix-ui/react-compose-refs" "1.1.2"
-    "@radix-ui/react-context" "1.1.2"
-    "@radix-ui/react-dismissable-layer" "1.1.11"
-    "@radix-ui/react-focus-guards" "1.1.3"
-    "@radix-ui/react-focus-scope" "1.1.7"
-    "@radix-ui/react-id" "1.1.1"
-    "@radix-ui/react-portal" "1.1.9"
-    "@radix-ui/react-presence" "1.1.5"
-    "@radix-ui/react-primitive" "2.1.3"
-    "@radix-ui/react-slot" "1.2.3"
-    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/primitive" "1.1.4"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.1.4"
+    "@radix-ui/react-dismissable-layer" "1.1.12"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.9"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-portal" "1.1.11"
+    "@radix-ui/react-presence" "1.1.6"
+    "@radix-ui/react-primitive" "2.1.5"
+    "@radix-ui/react-slot" "1.2.5"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
     aria-hidden "^1.2.4"
-    react-remove-scroll "^2.6.3"
+    react-remove-scroll "^2.7.2"
 
-"@radix-ui/react-direction@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.1.tgz#39e5a5769e676c753204b792fbe6cf508e550a14"
-  integrity sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==
+"@radix-ui/react-direction@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.2.tgz#9cc69edd659d79fba4101ee0e2dbcffc2024504f"
+  integrity sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==
 
-"@radix-ui/react-dismissable-layer@1.1.11":
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz#e33ab6f6bdaa00f8f7327c408d9f631376b88b37"
-  integrity sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==
+"@radix-ui/react-dismissable-layer@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz#f06a8f796e6fb7fa7a102cbb3c754024b43ef7f6"
+  integrity sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==
   dependencies:
-    "@radix-ui/primitive" "1.1.3"
-    "@radix-ui/react-compose-refs" "1.1.2"
-    "@radix-ui/react-primitive" "2.1.3"
-    "@radix-ui/react-use-callback-ref" "1.1.1"
-    "@radix-ui/react-use-escape-keydown" "1.1.1"
+    "@radix-ui/primitive" "1.1.4"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.5"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-escape-keydown" "1.1.2"
 
-"@radix-ui/react-focus-guards@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz#2a5669e464ad5fde9f86d22f7fdc17781a4dfa7f"
-  integrity sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==
+"@radix-ui/react-focus-guards@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz#3ef07a117ae7aa1430442aaebd766507e69d391c"
+  integrity sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==
 
-"@radix-ui/react-focus-scope@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz#dfe76fc103537d80bf42723a183773fd07bfb58d"
-  integrity sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==
-  dependencies:
-    "@radix-ui/react-compose-refs" "1.1.2"
-    "@radix-ui/react-primitive" "2.1.3"
-    "@radix-ui/react-use-callback-ref" "1.1.1"
-
-"@radix-ui/react-id@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"
-  integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
-  dependencies:
-    "@radix-ui/react-use-layout-effect" "1.1.1"
-
-"@radix-ui/react-portal@1.1.9":
+"@radix-ui/react-focus-scope@1.1.9":
   version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.9.tgz#14c3649fe48ec474ac51ed9f2b9f5da4d91c4472"
-  integrity sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz#c62ac82db36b01957f65a0b4a790f6e85cb0dac3"
+  integrity sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==
   dependencies:
-    "@radix-ui/react-primitive" "2.1.3"
-    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.5"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
 
-"@radix-ui/react-presence@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.5.tgz#5d8f28ac316c32f078afce2996839250c10693db"
-  integrity sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==
+"@radix-ui/react-id@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.2.tgz#6fe97e7289c7133b44f8c9c61fdddf2a6be1421d"
+  integrity sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==
   dependencies:
-    "@radix-ui/react-compose-refs" "1.1.2"
-    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
 
-"@radix-ui/react-primitive@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
-  integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
-  dependencies:
-    "@radix-ui/react-slot" "1.2.3"
-
-"@radix-ui/react-roving-focus@1.1.11":
+"@radix-ui/react-portal@1.1.11":
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz#ef54384b7361afc6480dcf9907ef2fedb5080fd9"
-  integrity sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.11.tgz#19b2e380268fe7b78bbcfeb953f049f32b0a11af"
+  integrity sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==
   dependencies:
-    "@radix-ui/primitive" "1.1.3"
-    "@radix-ui/react-collection" "1.1.7"
-    "@radix-ui/react-compose-refs" "1.1.2"
-    "@radix-ui/react-context" "1.1.2"
-    "@radix-ui/react-direction" "1.1.1"
-    "@radix-ui/react-id" "1.1.1"
-    "@radix-ui/react-primitive" "2.1.3"
-    "@radix-ui/react-use-callback-ref" "1.1.1"
-    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-primitive" "2.1.5"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
 
-"@radix-ui/react-slot@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"
-  integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
+"@radix-ui/react-presence@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.6.tgz#f0edff4f119dbc8ef81611e539a8f58d9afb33c3"
+  integrity sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==
   dependencies:
-    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
 
-"@radix-ui/react-slot@^1.2.0":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.4.tgz#63c0ba05fdf90cc49076b94029c852d7bac1fb83"
-  integrity sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==
+"@radix-ui/react-primitive@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz#4582608da1cde691c8c9a7642666c6f648ee601f"
+  integrity sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==
   dependencies:
-    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-slot" "1.2.5"
+
+"@radix-ui/react-roving-focus@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.12.tgz#e0879d7f74b54fac040ef2c207abbfff9049130b"
+  integrity sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.4"
+    "@radix-ui/react-collection" "1.1.9"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.1.4"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.5"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+
+"@radix-ui/react-slot@1.2.5", "@radix-ui/react-slot@^1.2.0":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.5.tgz#159bf186ee6e6f07240941c2b1a228097f0c69fa"
+  integrity sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.3"
 
 "@radix-ui/react-tabs@^1.1.12":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz#3537ce379d7e7ff4eeb6b67a0973e139c2ac1f15"
-  integrity sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.1.14.tgz#72a4f0915954a38dbdae4ca029455fbe923d915a"
+  integrity sha512-D5jwp9JNuwDeCw3CYD2Fz+sSHo0droQjC8u75dJHe4aWr5q6yBiXZU+hurXnKudRgEpUkD5TsI6bjHPo5ThUxA==
   dependencies:
-    "@radix-ui/primitive" "1.1.3"
-    "@radix-ui/react-context" "1.1.2"
-    "@radix-ui/react-direction" "1.1.1"
-    "@radix-ui/react-id" "1.1.1"
-    "@radix-ui/react-presence" "1.1.5"
-    "@radix-ui/react-primitive" "2.1.3"
-    "@radix-ui/react-roving-focus" "1.1.11"
-    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/primitive" "1.1.4"
+    "@radix-ui/react-context" "1.1.4"
+    "@radix-ui/react-direction" "1.1.2"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-presence" "1.1.6"
+    "@radix-ui/react-primitive" "2.1.5"
+    "@radix-ui/react-roving-focus" "1.1.12"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
 
-"@radix-ui/react-use-callback-ref@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
-  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
+"@radix-ui/react-use-callback-ref@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz#ddc0bc1381ff3b62368c248808efc45a098bafde"
+  integrity sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==
 
-"@radix-ui/react-use-controllable-state@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz#905793405de57d61a439f4afebbb17d0645f3190"
-  integrity sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==
+"@radix-ui/react-use-controllable-state@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz#516996f6443207546aa15a59bc71cdf5b54e01d1"
+  integrity sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==
   dependencies:
-    "@radix-ui/react-use-effect-event" "0.0.2"
-    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-effect-event" "0.0.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
 
-"@radix-ui/react-use-effect-event@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz#090cf30d00a4c7632a15548512e9152217593907"
-  integrity sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==
+"@radix-ui/react-use-effect-event@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz#e8f45e8e6ef64ce5bea7b5a9effc373f067e3530"
+  integrity sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==
   dependencies:
-    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
 
-"@radix-ui/react-use-escape-keydown@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz#b3fed9bbea366a118f40427ac40500aa1423cc29"
-  integrity sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==
+"@radix-ui/react-use-escape-keydown@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz#d63d64956da411192ef15d8c274b94d7d0adb038"
+  integrity sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==
   dependencies:
-    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
 
-"@radix-ui/react-use-layout-effect@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
-  integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
+"@radix-ui/react-use-layout-effect@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz#c882e66497174d061f250e65251974b699c65b65"
+  integrity sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==
 
 "@react-native-async-storage/async-storage@2.2.0":
   version "2.2.0"
@@ -1381,9 +1373,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/node@*":
-  version "25.9.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.1.tgz#3bda556db500ae4319c08e7fc9ab94f19013ba0b"
-  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+  version "25.9.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.2.tgz#fc8958e757994b71fee516f9634bdb03d1b19e9f"
+  integrity sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
 
@@ -1395,9 +1387,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@~19.2.14":
-  version "19.2.16"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.16.tgz#9868b153fd9e34e0117afcd5d7e372b8179337e1"
-  integrity sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==
+  version "19.2.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.17.tgz#dccac365baa0f1734ec270ff4b51c89465e8dc7f"
+  integrity sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==
   dependencies:
     csstype "^3.2.2"
 
@@ -1419,7 +1411,7 @@
   integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
 
 "@wwdrew/expo-spotify-sdk@file:..":
-  version "2.0.0"
+  version "2.2.1"
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.13"
@@ -1657,9 +1649,9 @@ base64-js@^1.5.1:
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.33"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz#27c299b096404978831958d429f48390424c4f9b"
-  integrity sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==
+  version "2.10.34"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz#dedb606362446777cfe328d30d4ee15056d06303"
+  integrity sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==
 
 big-integer@1.6.x:
   version "1.6.52"
@@ -1742,9 +1734,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001782:
-  version "1.0.30001793"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz#238887ddf5fcfc8c36d872394d0a78a517312a72"
-  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
+  version "1.0.30001797"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz#1332709e1439f01ff92085dd17001e0a45897ec0"
+  integrity sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==
 
 chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
@@ -2015,9 +2007,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.328:
-  version "1.5.366"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz#54cfb4090db768d58dce9ef5a2f8b837e61ebe6b"
-  integrity sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==
+  version "1.5.370"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.370.tgz#47dbc6565e5f13991a483e10cddff4bf0933de96"
+  integrity sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -2076,18 +2068,18 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-expo-asset@~56.0.15:
-  version "56.0.15"
-  resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-56.0.15.tgz#468b63c4d49b68a7712eeb3c136db2a71be1de42"
-  integrity sha512-BHGi2IAOPQTcOelkUdcz1WIknfCTRjkcpYHX1azjMwgYenrVC+J5qcqJGaC8eUOWLCRtkRJWGnmFQRYtLU1nUQ==
+expo-asset@~56.0.16:
+  version "56.0.16"
+  resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-56.0.16.tgz#c5eb46cf2f96323a3d54fc464e17e23089d6d371"
+  integrity sha512-iIxPo6C6+/d8JxGV74ZKZbIcCz2s8//dVl7oBAj124NcPMFhzdwycFBpMqq5LUxin+lVy5cCoEjv2LD8ulnkiQ==
   dependencies:
     "@expo/image-utils" "^0.10.1"
-    expo-constants "~56.0.16"
+    expo-constants "~56.0.17"
 
-expo-constants@~56.0.16:
-  version "56.0.16"
-  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-56.0.16.tgz#94f2ed4f83ce1b1c6a36372124c05cc9abcf8d58"
-  integrity sha512-6tsiN+gmTUPp/atyA+uY9Tg8VOdXdmb4s/3TVGolfn6A/oCAraw1pcPZX5XllyD+xUguxB6eBSFAT8494hZVMA==
+expo-constants@~56.0.16, expo-constants@~56.0.17:
+  version "56.0.17"
+  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-56.0.17.tgz#8a1900cf536edc69ea57887782b32ec33c7fd1f0"
+  integrity sha512-bU8iU1+7cI7QzfGQVnz2C1nlbXD08YPwD6h8ZEuNspgUuD2prXfmrhrdLe1GjCPYGw4hB3BNjWPjpenNyyymfQ==
   dependencies:
     "@expo/env" "~2.3.0"
 
@@ -2121,39 +2113,39 @@ expo-linking@~56.0.12:
     expo-constants "~56.0.16"
     invariant "^2.2.4"
 
-expo-modules-autolinking@~56.0.14:
-  version "56.0.14"
-  resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-56.0.14.tgz#6aed55b0afe39c341bb4cc443ec142d68213dec2"
-  integrity sha512-9ugtZkheNPYDkW4DZopY1rH2BCbUICaafUEPxRgbLDR5UNRF5K3cdHMIMEt8pxZPq2+eX4wCm+6pbSvdY/DPHg==
+expo-modules-autolinking@~56.0.15:
+  version "56.0.15"
+  resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-56.0.15.tgz#a5be0a331410de6638cccd137def0efc1aab7cb3"
+  integrity sha512-WqpBFwLzn7DsrUkWltIjVmAjwuI1VdQ2jRMlvk1nh2kVadwdJBkSjUBQWRifsEePNhiMT/rFOovBolUU/ARt5w==
   dependencies:
     "@expo/require-utils" "^56.1.3"
     "@expo/spawn-async" "^1.8.0"
     chalk "^4.1.0"
     commander "^7.2.0"
 
-expo-modules-core@~56.0.14:
-  version "56.0.14"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-56.0.14.tgz#620263e7265f0bcca04d7490ea0b139a5ea9bd89"
-  integrity sha512-dl1TlYRm1k7xk9QeAyDoMfFE2p6rNyzHUcH5ArcGwUzO8YKku+Z2tQ8+kG7zLe3OhfMoJcFR/czrFy7vGSVI6w==
+expo-modules-core@~56.0.15:
+  version "56.0.15"
+  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-56.0.15.tgz#63e8a3e58a1cf917db149a8d7efaa55edb41d82e"
+  integrity sha512-XOXuWjtUA/xF8VjMHoRTRxuAmrAeUv8QyASX3h/CpTNS58fOt3stV8EYW7BinJPJyqwV7BZoYV83iN0p2FzyZw==
   dependencies:
     "@expo/expo-modules-macros-plugin" "~0.0.9"
-    expo-modules-jsi "~56.0.7"
+    expo-modules-jsi "~56.0.8"
     invariant "^2.2.4"
 
-expo-modules-jsi@~56.0.7:
-  version "56.0.7"
-  resolved "https://registry.yarnpkg.com/expo-modules-jsi/-/expo-modules-jsi-56.0.7.tgz#4246c6e9ad91ce89bc3c3ec47bc6285f29de90f7"
-  integrity sha512-iBAj4Xeh/8HT201VVxFlmf+VBfmtQV1ZUoJdLQQENm0+j9gnD2QswZLJyNo3CmNNXl46esJeLR5lpGpYZts/zA==
+expo-modules-jsi@~56.0.8:
+  version "56.0.8"
+  resolved "https://registry.yarnpkg.com/expo-modules-jsi/-/expo-modules-jsi-56.0.8.tgz#c5bd6b29d0e586840cbe4d051da68d9a8789c419"
+  integrity sha512-tXqFU1MHrf7Ctq+Pw0qOeIPDFl1W51p9nRRZy9vVUn4GNuAk1Av0vrj0SGLvcxJvDf3aGwSzr8o8dgUsX5sG0g==
 
 expo-router@~56.2.7:
-  version "56.2.8"
-  resolved "https://registry.yarnpkg.com/expo-router/-/expo-router-56.2.8.tgz#57c233cd564340cf3e8076ab06b6fcc890270c70"
-  integrity sha512-l387I/ddPY/5SS+Rfpp1SrRV9gBKevxtPuZod7igMjR6L674QrxEwGiAILRq6AKCSbrP2I0ufKj7e5xz8JqA4Q==
+  version "56.2.9"
+  resolved "https://registry.yarnpkg.com/expo-router/-/expo-router-56.2.9.tgz#3e54edee2abb746a770e0d52a4a70ffd59c9b9b5"
+  integrity sha512-MuGL7Ht8hFTo1ddntyXGw5Lh+5rBw8S/0wHCwtI88nv4aCSyLEuFE19i4E/G0BXVCTKeDRu/hOww3jEqUlAN2w==
   dependencies:
     "@expo/log-box" "^56.0.12"
-    "@expo/metro-runtime" "^56.0.13"
+    "@expo/metro-runtime" "^56.0.14"
     "@expo/schema-utils" "^56.0.0"
-    "@expo/ui" "^56.0.15"
+    "@expo/ui" "^56.0.16"
     "@radix-ui/react-slot" "^1.2.0"
     "@radix-ui/react-tabs" "^1.1.12"
     "@react-native-masked-view/masked-view" "^0.3.2"
@@ -2164,8 +2156,8 @@ expo-router@~56.2.7:
     debug "^4.3.4"
     escape-string-regexp "^4.0.0"
     expo-glass-effect "^56.0.4"
-    expo-server "^56.0.4"
-    expo-symbols "^56.0.5"
+    expo-server "^56.0.5"
+    expo-symbols "^56.0.6"
     fast-deep-equal "^3.1.3"
     invariant "^2.2.4"
     nanoid "^3.3.8"
@@ -2179,10 +2171,10 @@ expo-router@~56.2.7:
     shallowequal "^1.1.0"
     vaul "^1.1.2"
 
-expo-server@^56.0.4:
-  version "56.0.4"
-  resolved "https://registry.yarnpkg.com/expo-server/-/expo-server-56.0.4.tgz#b3c60b3a0c8949c2c73c7576a80db7998a1ce57f"
-  integrity sha512-4dJ57KuAwDl7eQGD6aG9kTzBIftWAfHH1+6Zxy7NcPCBrKYis3/H5enGUz1asH8HHhONXfJ5BdJqfEWAEAgWxA==
+expo-server@^56.0.5:
+  version "56.0.5"
+  resolved "https://registry.yarnpkg.com/expo-server/-/expo-server-56.0.5.tgz#601e9a80d166cb65b35f6a38e7a61dc6de12b91d"
+  integrity sha512-SmM2p2g3Jrktpiazcst+OxhjSzOHXKAY4BPURHYHXvApzzoybMmrNF4IEZ8DKZ145BhSe4ydAmlEFCRTsdtgUQ==
 
 expo-splash-screen@~56.0.10:
   version "56.0.10"
@@ -2198,10 +2190,10 @@ expo-status-bar@~56.0.4:
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-56.0.4.tgz#01a0b6f9946ae51fe9d85c961ae9b485383cfcab"
   integrity sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA==
 
-expo-symbols@^56.0.5:
-  version "56.0.5"
-  resolved "https://registry.yarnpkg.com/expo-symbols/-/expo-symbols-56.0.5.tgz#6cab53682d7e4304bdf0419579eeec52ee3f1e80"
-  integrity sha512-RIukH0Xo80C7RU8qreipL2SPy2Py+Km8JFPbCmbPQpHkM3DW9Znlmg6VfhzbtUOlO5EuNSF0lAJ3l2VJi6qYrw==
+expo-symbols@^56.0.6:
+  version "56.0.6"
+  resolved "https://registry.yarnpkg.com/expo-symbols/-/expo-symbols-56.0.6.tgz#02e5f6154e0a7445981ea3634d8069cfe3148fb1"
+  integrity sha512-BrA81DjcNafdj7gXVhdrExb9LtUiSVyOf/NavyMmDAHgHMY1GqeR5cnn1PSAZeYKnSgQhee/H89XUpAxtog5hg==
   dependencies:
     "@expo-google-fonts/material-symbols" "^0.4.1"
     sf-symbols-typescript "^2.0.0"
@@ -2215,30 +2207,30 @@ expo-system-ui@~56.0.5:
     debug "^4.3.2"
 
 expo@~56.0.0:
-  version "56.0.8"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-56.0.8.tgz#1f2ff8f904e9b9502e3b6c9fcd85aba7911b6847"
-  integrity sha512-GzQi5450yrCk5JRSlm0epsmtURBErh0wS77uWLZImFdnPICuX912MaRWooR+Q1Sw/7aQjp9F+KXH+dvrqGxpeQ==
+  version "56.0.9"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-56.0.9.tgz#607a7a7fe42e07966e2e81ef0de12426f7393441"
+  integrity sha512-Zd/fhhyC600PO4cA14r+K+DlhhUZLNaDNF6dYg+hgne2kLvg9HMnkZ902sTPZYLkW56JOXLJ5dk7hsIoH26N2A==
   dependencies:
     "@babel/runtime" "^7.20.0"
-    "@expo/cli" "^56.1.13"
+    "@expo/cli" "^56.1.14"
     "@expo/config" "~56.0.9"
     "@expo/config-plugins" "~56.0.8"
     "@expo/devtools" "~56.0.2"
     "@expo/dom-webview" "~56.0.5"
-    "@expo/fingerprint" "^0.19.3"
+    "@expo/fingerprint" "^0.19.4"
     "@expo/local-build-cache-provider" "^56.0.8"
     "@expo/log-box" "^56.0.12"
     "@expo/metro" "~56.0.0"
     "@expo/metro-config" "~56.0.13"
     "@ungap/structured-clone" "^1.3.0"
     babel-preset-expo "~56.0.14"
-    expo-asset "~56.0.15"
-    expo-constants "~56.0.16"
+    expo-asset "~56.0.16"
+    expo-constants "~56.0.17"
     expo-file-system "~56.0.7"
     expo-font "~56.0.5"
     expo-keep-awake "~56.0.3"
-    expo-modules-autolinking "~56.0.14"
-    expo-modules-core "~56.0.14"
+    expo-modules-autolinking "~56.0.15"
+    expo-modules-core "~56.0.15"
     pretty-format "^29.7.0"
     react-refresh "^0.14.2"
     whatwg-url-minimum "^0.1.2"
@@ -3074,9 +3066,9 @@ msgpackr-extract@^3.0.4:
     "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.4"
 
 msgpackr@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-2.0.2.tgz#2b9838ba796d4c9760878a04d4fa69391178b5ac"
-  integrity sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-2.0.4.tgz#a7cb0307fe59bf21a69d378b0fa279cdc1a3c49f"
+  integrity sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==
   optionalDependencies:
     msgpackr-extract "^3.0.4"
 
@@ -3392,9 +3384,9 @@ react-is@^19.1.0:
   integrity sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==
 
 react-native-drawer-layout@^4.2.2:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-4.2.4.tgz#06d850f6599fd2be2558073ddf073913780971f3"
-  integrity sha512-l1Le5HcVidobnJm8xqFZo46Rs8FDHdxbTZhkjxpNSRgU+QMoQXilOfzTHAeNjEGiKVGgIs9cW3ctXeHqgp5jJg==
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-4.2.5.tgz#cccc4200ad92535e4b69784b3464a81301adec70"
+  integrity sha512-Yl82uLkXjXuq7222hWGIDsq5A6R/bsCeCEgdIxQUxAEHf00oRdDnRByLx3Fsij3qwtmYNPGrHV1NH8G8hbCbLQ==
   dependencies:
     color "^4.2.3"
     use-latest-callback "^0.2.4"
@@ -3473,7 +3465,7 @@ react-remove-scroll-bar@^2.3.7:
     react-style-singleton "^2.2.2"
     tslib "^2.0.0"
 
-react-remove-scroll@^2.6.3:
+react-remove-scroll@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
   integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
@@ -3605,9 +3597,9 @@ semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.1.3, semver@^7.3.5, semver@^7.5.4, semver@^7.6.0:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
-  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.3.tgz#c350de61c2a1ddbc96d7fae3e5b6fcf92d477fbe"
+  integrity sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==
 
 send@^0.19.0, send@~0.19.1:
   version "0.19.2"

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -2,7 +2,8 @@
   "platforms": ["ios", "android", "web"],
   "ios": {
     "modules": ["ExpoSpotifySDKModule"],
-    "appDelegateSubscribers": ["ExpoSpotifyAppDelegate"]
+    "appDelegateSubscribers": ["ExpoSpotifyAppDelegate"],
+    "podspecPath": "ios/ExpoSpotifySDK.podspec"
   },
   "android": {
     "modules": ["expo.modules.spotifysdk.ExpoSpotifySDKModule"]

--- a/ios/ExpoSpotifySDK.podspec
+++ b/ios/ExpoSpotifySDK.podspec
@@ -1,18 +1,6 @@
 require 'json'
 
-absolute_react_native_path = ''
-if !ENV['REACT_NATIVE_PATH'].nil?
-  absolute_react_native_path = File.expand_path(ENV['REACT_NATIVE_PATH'], Pod::Config.instance.project_root)
-else
-  absolute_react_native_path = File.dirname(`node --print "require.resolve('react-native/package.json')"`)
-end
-
-unless defined?(spm_dependency)
-  require File.join(absolute_react_native_path, "scripts/react_native_pods")
-end
-
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
-spotify_native = JSON.parse(File.read(File.join(__dir__, 'spotify-native-sdk-versions.json')))
 
 Pod::Spec.new do |s|
   s.name           = 'ExpoSpotifySDK'
@@ -28,6 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
+  s.dependency 'SpotifyiOS'
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
@@ -35,18 +24,4 @@ Pod::Spec.new do |s|
   }
 
   s.source_files = "**/*.{h,m,swift}"
-
-  ios_sdk = spotify_native['ios']
-  if ios_sdk.nil? ||
-      ios_sdk['spmRepositoryUrl'].to_s.empty? ||
-      ios_sdk['spmVersion'].to_s.empty? ||
-      ios_sdk['spmProduct'].to_s.empty?
-    raise "ios/spotify-native-sdk-versions.json is missing required iOS fields: spmRepositoryUrl, spmVersion, spmProduct"
-  end
-
-  spm_dependency(s,
-    url: ios_sdk['spmRepositoryUrl'],
-    requirement: { kind: 'exactVersion', version: ios_sdk['spmVersion'] },
-    products: [ios_sdk['spmProduct']]
-  )
 end

--- a/ios/spotify-native-sdk-versions.json
+++ b/ios/spotify-native-sdk-versions.json
@@ -1,8 +1,8 @@
 {
   "ios": {
-    "spmRepositoryUrl": "https://github.com/spotify/ios-sdk.git",
-    "spmVersion": "5.0.1",
-    "spmProduct": "SpotifyiOS"
+    "version": "5.0.1",
+    "tarballSha256": "acafc07d35ce3f0bce93cac0031cd1cca1ba7ba6647a3e07e123f2e954ec298b",
+    "binarySha256": "988704167a3839136c7a4fd83742fca1422dfad48de41354ed07aa8e47611e32"
   },
   "android": {
     "appRemoteVersion": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clean": "rm -rf build plugin/build android/build",
     "lint": "eslint src",
     "test": "jest --config jest.config.js",
-    "prepublishOnly": "yarn clean && yarn build && yarn build:plugin",
+    "prepublishOnly": "yarn clean && yarn build && yarn build:plugin && bash scripts/verify-npm-pack.sh",
     "typecheck": "tsc --noEmit",
     "open:ios": "open -a \"Xcode\" example/ios",
     "open:android": "open -a \"Android Studio\" example/android"
@@ -43,6 +43,7 @@
     "android/src",
     "android/libs/SETUP.md",
     "ios/spotify-native-sdk-versions.json",
+    "spotify-ios/SpotifyiOS.podspec",
     "ios/*.swift",
     "ios/*.podspec",
     "app.plugin.js",

--- a/plugin/src/__tests__/withSpotifyIosPod.test.ts
+++ b/plugin/src/__tests__/withSpotifyIosPod.test.ts
@@ -1,0 +1,56 @@
+import { withPodfile } from "@expo/config-plugins";
+import {
+  applySpotifyIosPod,
+  PODFILE_SPOTIFY_IOS_POD,
+  withSpotifyIosPod,
+} from "../ios/withSpotifyIosPod";
+
+jest.mock("@expo/config-plugins", () => ({
+  withPodfile: jest.fn(),
+}));
+
+const mockedWithPodfile = jest.mocked(withPodfile);
+
+const SAMPLE_PODFILE = `platform :ios, '16.4'
+
+target 'MyApp' do
+  use_expo_modules!
+end
+`;
+
+describe("applySpotifyIosPod", () => {
+  it("injects SpotifyiOS pod line after use_expo_modules!", () => {
+    const result = applySpotifyIosPod(SAMPLE_PODFILE);
+    expect(result).toContain(PODFILE_SPOTIFY_IOS_POD);
+    expect(result.indexOf("use_expo_modules!")).toBeLessThan(
+      result.indexOf("pod 'SpotifyiOS'"),
+    );
+  });
+
+  it("is idempotent when applied twice", () => {
+    const once = applySpotifyIosPod(SAMPLE_PODFILE);
+    const twice = applySpotifyIosPod(once);
+    expect(twice).toBe(once);
+  });
+});
+
+describe("withSpotifyIosPod", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("modifies the Podfile via withPodfile", () => {
+    mockedWithPodfile.mockImplementation((config, fn) =>
+      (fn as Function)({
+        ...config,
+        modResults: { contents: SAMPLE_PODFILE },
+      }),
+    );
+
+    const result = withSpotifyIosPod({
+      name: "test",
+      slug: "test",
+    } as any) as any;
+
+    expect(mockedWithPodfile).toHaveBeenCalled();
+    expect(result.modResults.contents).toContain("pod 'SpotifyiOS'");
+  });
+});

--- a/plugin/src/ios/withSpotifyIosPod.ts
+++ b/plugin/src/ios/withSpotifyIosPod.ts
@@ -1,0 +1,34 @@
+import { ConfigPlugin, withPodfile } from "@expo/config-plugins";
+import { mergeContents } from "@expo/config-plugins/build/utils/generateCode";
+
+export const PODFILE_SPOTIFY_IOS_TAG = "expo-spotify-sdk-spotify-ios-pod";
+
+/**
+ * Standard CocoaPods binary pod — SpotifyiOS.podspec uses `source: { http: ... }`
+ * so CocoaPods downloads and runs `prepare_command` (unlike `:path` pods).
+ */
+export const PODFILE_SPOTIFY_IOS_POD = `  pod 'SpotifyiOS', :podspec => File.join(__dir__, '../node_modules/@wwdrew/expo-spotify-sdk/spotify-ios/SpotifyiOS.podspec')`;
+
+export function applySpotifyIosPod(podfileContents: string): string {
+  const merged = mergeContents({
+    tag: PODFILE_SPOTIFY_IOS_TAG,
+    src: podfileContents,
+    newSrc: PODFILE_SPOTIFY_IOS_POD,
+    anchor: /use_expo_modules!/,
+    offset: 1,
+    comment: "#",
+  });
+
+  return merged.didMerge || merged.didClear
+    ? merged.contents
+    : podfileContents;
+}
+
+export const withSpotifyIosPod: ConfigPlugin = (config) => {
+  return withPodfile(config, (config) => {
+    config.modResults.contents = applySpotifyIosPod(
+      config.modResults.contents,
+    );
+    return config;
+  });
+};

--- a/plugin/src/withSpotifySdkConfig.ts
+++ b/plugin/src/withSpotifySdkConfig.ts
@@ -2,6 +2,7 @@ import { ConfigPlugin } from "@expo/config-plugins";
 
 import { withSpotifyAndroidAppBuildGradle } from "./android/withSpotifyAndroidAppBuildGradle";
 import { withSpotifyConfigValues } from "./ios/withSpotifyConfigValues";
+import { withSpotifyIosPod } from "./ios/withSpotifyIosPod";
 import { withSpotifyQueryScheme } from "./ios/withSpotifyQueryScheme";
 import { withSpotifyURLScheme } from "./ios/withSpotifyURLScheme";
 import { SpotifyConfig } from "./types";
@@ -26,6 +27,7 @@ export const withSpotifySdkConfig: ConfigPlugin<SpotifyConfig> = (
   config = withSpotifyAndroidAppBuildGradle(config, spotifyConfig);
 
   // iOS specific
+  config = withSpotifyIosPod(config);
   config = withSpotifyConfigValues(config, spotifyConfig);
   config = withSpotifyQueryScheme(config, spotifyConfig);
   config = withSpotifyURLScheme(config, spotifyConfig);

--- a/scripts/verify-npm-pack.sh
+++ b/scripts/verify-npm-pack.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Spotify native binaries must NOT be in the npm tarball (fetched at app build time).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+LIST="$(mktemp)"
+trap 'rm -f "$LIST"' EXIT
+
+npm pack --dry-run 2>&1 | tee "$LIST"
+
+FAIL=0
+
+if grep -q 'SpotifyiOS.xcframework/ios-arm64/SpotifyiOS.framework/SpotifyiOS' "$LIST"; then
+  echo "error: npm pack must not include SpotifyiOS.xcframework"
+  FAIL=1
+fi
+
+if ! grep -q 'spotify-ios/SpotifyiOS.podspec' "$LIST"; then
+  echo "error: npm pack is missing spotify-ios/SpotifyiOS.podspec"
+  FAIL=1
+fi
+
+if grep -qE 'android/build/' "$LIST"; then
+  echo "error: npm pack includes android/build artifacts"
+  grep -E 'android/build/' "$LIST" | head -5
+  FAIL=1
+fi
+
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "verify-npm-pack: ok (no Spotify binaries bundled)"

--- a/spotify-ios/SpotifyiOS.podspec
+++ b/spotify-ios/SpotifyiOS.podspec
@@ -1,0 +1,37 @@
+require 'json'
+
+pins = JSON.parse(File.read(File.join(__dir__, '..', 'ios', 'spotify-native-sdk-versions.json')))['ios']
+version = pins['version']
+tag = "v#{version}"
+
+Pod::Spec.new do |s|
+  s.name             = 'SpotifyiOS'
+  s.version          = version
+  s.summary          = 'Spotify iOS SDK (binary pod for @wwdrew/expo-spotify-sdk)'
+  s.homepage         = 'https://github.com/spotify/ios-sdk'
+  s.license          = { :type => 'Proprietary' }
+  s.author           = 'Spotify'
+  s.platform         = :ios, '16.4'
+  s.static_framework = true
+
+  s.source = {
+    :http => "https://github.com/spotify/ios-sdk/archive/refs/tags/#{tag}.tar.gz",
+  }
+
+  s.prepare_command = <<-CMD
+    set -e
+    if [ ! -d SpotifyiOS.xcframework ]; then
+      framework="$(find . -name 'SpotifyiOS.xcframework' -type d | head -1)"
+      test -n "$framework"
+      mv "$framework" .
+    fi
+    if [ ! -d Licenses ]; then
+      licenses="$(find . -path '*/Licenses' -type d | head -1)"
+      if [ -n "$licenses" ]; then mv "$licenses" .; fi
+    fi
+    find . -mindepth 1 -maxdepth 1 ! -name 'SpotifyiOS.xcframework' ! -name 'Licenses' -exec rm -rf {} +
+  CMD
+
+  s.vendored_frameworks = 'SpotifyiOS.xcframework'
+  s.preserve_paths = 'Licenses'
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,16 +1665,16 @@
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
 "@types/node@*":
-  version "25.9.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.1.tgz#3bda556db500ae4319c08e7fc9ab94f19013ba0b"
-  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+  version "25.9.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.2.tgz#fc8958e757994b71fee516f9634bdb03d1b19e9f"
+  integrity sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
 
 "@types/react@^19.0.0":
-  version "19.2.16"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.16.tgz#9868b153fd9e34e0117afcd5d7e372b8179337e1"
-  integrity sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==
+  version "19.2.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.17.tgz#dccac365baa0f1734ec270ff4b51c89465e8dc7f"
+  integrity sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==
   dependencies:
     csstype "^3.2.2"
 
@@ -1701,99 +1701,99 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^8.59.0":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz#c1060bb8fa4be80624d3f3dec8dd9caca373af76"
-  integrity sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz#db20271974b94a3a54d3b9544e5f5b3481448400"
+  integrity sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==
   dependencies:
     "@eslint-community/regexpp" "^4.12.2"
-    "@typescript-eslint/scope-manager" "8.60.1"
-    "@typescript-eslint/type-utils" "8.60.1"
-    "@typescript-eslint/utils" "8.60.1"
-    "@typescript-eslint/visitor-keys" "8.60.1"
+    "@typescript-eslint/scope-manager" "8.61.0"
+    "@typescript-eslint/type-utils" "8.61.0"
+    "@typescript-eslint/utils" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
     ignore "^7.0.5"
     natural-compare "^1.4.0"
     ts-api-utils "^2.5.0"
 
 "@typescript-eslint/parser@^8.59.0":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.60.1.tgz#a9d7f30850384d34b41f4687dd8944823c09e289"
-  integrity sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.61.0.tgz#1afe73c9ccce16b7a26d6b95f9400b0ccc34af87"
+  integrity sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==
   dependencies:
-    "@typescript-eslint/scope-manager" "8.60.1"
-    "@typescript-eslint/types" "8.60.1"
-    "@typescript-eslint/typescript-estree" "8.60.1"
-    "@typescript-eslint/visitor-keys" "8.60.1"
+    "@typescript-eslint/scope-manager" "8.61.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/typescript-estree" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
     debug "^4.4.3"
 
-"@typescript-eslint/project-service@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.60.1.tgz#eb29712f58d72c222fc727162e92f2ab4670971b"
-  integrity sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==
+"@typescript-eslint/project-service@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.61.0.tgz#417a2feac32e8ebd336d63f068c3b42b736ea1ac"
+  integrity sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==
   dependencies:
-    "@typescript-eslint/tsconfig-utils" "^8.60.1"
-    "@typescript-eslint/types" "^8.60.1"
+    "@typescript-eslint/tsconfig-utils" "^8.61.0"
+    "@typescript-eslint/types" "^8.61.0"
     debug "^4.4.3"
 
-"@typescript-eslint/scope-manager@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz#2f875962eaad0a0789cc3c36aea9b4ddeb2dd9c8"
-  integrity sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==
+"@typescript-eslint/scope-manager@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz#93c2520d05653fe65eb9ee98efc74fd0134a7852"
+  integrity sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==
   dependencies:
-    "@typescript-eslint/types" "8.60.1"
-    "@typescript-eslint/visitor-keys" "8.60.1"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
 
-"@typescript-eslint/tsconfig-utils@8.60.1", "@typescript-eslint/tsconfig-utils@^8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz#bee8b942a13679a878101c9c74577d732062ed93"
-  integrity sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==
+"@typescript-eslint/tsconfig-utils@8.61.0", "@typescript-eslint/tsconfig-utils@^8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz#05d6e3ff20001674ebcd22d03dac29ee448043ba"
+  integrity sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==
 
-"@typescript-eslint/type-utils@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz#1ae45f0f2a701354beea4a58c2161e40a5e3c379"
-  integrity sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==
+"@typescript-eslint/type-utils@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz#50219b57e6b89cecfb1a15f093b15ec9ee019974"
+  integrity sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==
   dependencies:
-    "@typescript-eslint/types" "8.60.1"
-    "@typescript-eslint/typescript-estree" "8.60.1"
-    "@typescript-eslint/utils" "8.60.1"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/typescript-estree" "8.61.0"
+    "@typescript-eslint/utils" "8.61.0"
     debug "^4.4.3"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/types@8.60.1", "@typescript-eslint/types@^8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.60.1.tgz#ccdc482ba9e17f9723a10ce240b5e67dad3046c4"
-  integrity sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==
+"@typescript-eslint/types@8.61.0", "@typescript-eslint/types@^8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.61.0.tgz#0ddb46e012a4288292950bdd253db42f278ce64d"
+  integrity sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==
 
-"@typescript-eslint/typescript-estree@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz#016630b119228bf483ddc652703a6a038f3fdd74"
-  integrity sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==
+"@typescript-eslint/typescript-estree@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz#98ca47260bbf627fc28f018b3a0abf00e3090690"
+  integrity sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==
   dependencies:
-    "@typescript-eslint/project-service" "8.60.1"
-    "@typescript-eslint/tsconfig-utils" "8.60.1"
-    "@typescript-eslint/types" "8.60.1"
-    "@typescript-eslint/visitor-keys" "8.60.1"
+    "@typescript-eslint/project-service" "8.61.0"
+    "@typescript-eslint/tsconfig-utils" "8.61.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/visitor-keys" "8.61.0"
     debug "^4.4.3"
     minimatch "^10.2.2"
     semver "^7.7.3"
     tinyglobby "^0.2.15"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/utils@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.60.1.tgz#31cf566095602d9fe8ad91837d2eb520b8de762b"
-  integrity sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==
+"@typescript-eslint/utils@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.61.0.tgz#ed3546a052787e84ea6c5064d0919fc5eea8522f"
+  integrity sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==
   dependencies:
     "@eslint-community/eslint-utils" "^4.9.1"
-    "@typescript-eslint/scope-manager" "8.60.1"
-    "@typescript-eslint/types" "8.60.1"
-    "@typescript-eslint/typescript-estree" "8.60.1"
+    "@typescript-eslint/scope-manager" "8.61.0"
+    "@typescript-eslint/types" "8.61.0"
+    "@typescript-eslint/typescript-estree" "8.61.0"
 
-"@typescript-eslint/visitor-keys@8.60.1":
-  version "8.60.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz#165d1d8901137b944efaf18f00ab5ecb57f06995"
-  integrity sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==
+"@typescript-eslint/visitor-keys@8.61.0":
+  version "8.61.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz#39b4e1ab8936d23bea973d39fd092f9aa21f275e"
+  integrity sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==
   dependencies:
-    "@typescript-eslint/types" "8.60.1"
+    "@typescript-eslint/types" "8.61.0"
     eslint-visitor-keys "^5.0.0"
 
 "@xmldom/xmldom@^0.8.8":
@@ -2207,9 +2207,9 @@ base64-js@^1.5.1:
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.33"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz#27c299b096404978831958d429f48390424c4f9b"
-  integrity sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==
+  version "2.10.34"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz#dedb606362446777cfe328d30d4ee15056d06303"
+  integrity sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==
 
 big-integer@1.6.x:
   version "1.6.52"
@@ -2329,9 +2329,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001782:
-  version "1.0.30001793"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz#238887ddf5fcfc8c36d872394d0a78a517312a72"
-  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
+  version "1.0.30001797"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz#1332709e1439f01ff92085dd17001e0a45897ec0"
+  integrity sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==
 
 chalk@^3.0.0:
   version "3.0.0"
@@ -2620,9 +2620,9 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     gopd "^1.2.0"
 
 electron-to-chromium@^1.5.328:
-  version "1.5.366"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz#54cfb4090db768d58dce9ef5a2f8b837e61ebe6b"
-  integrity sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==
+  version "1.5.370"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.370.tgz#47dbc6565e5f13991a483e10cddff4bf0933de96"
+  integrity sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -2635,9 +2635,9 @@ emoji-regex@^8.0.0:
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 enhanced-resolve@^5.17.1:
-  version "5.22.2"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz#b8ff1a9207130b9f5497031ec68d9acb040656e9"
-  integrity sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==
+  version "5.23.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz#dfdf8d1c9065e4b52f8a598356138931c07305f9"
+  integrity sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.3.3"
@@ -2753,7 +2753,7 @@ es-iterator-helpers@^1.2.1:
     iterator.prototype "^1.1.5"
     math-intrinsics "^1.1.0"
 
-es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1, es-object-atoms@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
   integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
@@ -3136,18 +3136,18 @@ expo-module-scripts@^56.0.2:
     ts-jest "~29.4.7"
 
 expo-modules-core@^56.0.13:
-  version "56.0.14"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-56.0.14.tgz#620263e7265f0bcca04d7490ea0b139a5ea9bd89"
-  integrity sha512-dl1TlYRm1k7xk9QeAyDoMfFE2p6rNyzHUcH5ArcGwUzO8YKku+Z2tQ8+kG7zLe3OhfMoJcFR/czrFy7vGSVI6w==
+  version "56.0.15"
+  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-56.0.15.tgz#63e8a3e58a1cf917db149a8d7efaa55edb41d82e"
+  integrity sha512-XOXuWjtUA/xF8VjMHoRTRxuAmrAeUv8QyASX3h/CpTNS58fOt3stV8EYW7BinJPJyqwV7BZoYV83iN0p2FzyZw==
   dependencies:
     "@expo/expo-modules-macros-plugin" "~0.0.9"
-    expo-modules-jsi "~56.0.7"
+    expo-modules-jsi "~56.0.8"
     invariant "^2.2.4"
 
-expo-modules-jsi@~56.0.7:
-  version "56.0.7"
-  resolved "https://registry.yarnpkg.com/expo-modules-jsi/-/expo-modules-jsi-56.0.7.tgz#4246c6e9ad91ce89bc3c3ec47bc6285f29de90f7"
-  integrity sha512-iBAj4Xeh/8HT201VVxFlmf+VBfmtQV1ZUoJdLQQENm0+j9gnD2QswZLJyNo3CmNNXl46esJeLR5lpGpYZts/zA==
+expo-modules-jsi@~56.0.8:
+  version "56.0.8"
+  resolved "https://registry.yarnpkg.com/expo-modules-jsi/-/expo-modules-jsi-56.0.8.tgz#c5bd6b29d0e586840cbe4d051da68d9a8789c419"
+  integrity sha512-tXqFU1MHrf7Ctq+Pw0qOeIPDFl1W51p9nRRZy9vVUn4GNuAk1Av0vrj0SGLvcxJvDf3aGwSzr8o8dgUsX5sG0g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -4660,9 +4660,9 @@ nullthrows@^1.1.1:
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
 nwsapi@^2.2.2:
-  version "2.2.23"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.23.tgz#59712c3a88e6de2bb0b6ccc1070397267019cf6c"
-  integrity sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==
+  version "2.2.24"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
+  integrity sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -4909,9 +4909,9 @@ prettier-linter-helpers@^1.0.1:
     fast-diff "^1.1.2"
 
 prettier@^3.0.0:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.3.tgz#560f2de55bf01b4c0503bc629d5df99b9a1d09b0"
-  integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.4.tgz#f334f013ac04a96676f24dabc23c1c4ae1bae411"
+  integrity sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==
 
 pretty-format@30.4.1, pretty-format@^30.0.5:
   version "30.4.1"
@@ -5216,9 +5216,9 @@ semver@^6.1.0, semver@^6.3.0, semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.5.3, semver@^7.5.4, semver@^7.6.3, semver@^7.7.3, semver@^7.8.0:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
-  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.3.tgz#c350de61c2a1ddbc96d7fae3e5b6fcf92d477fbe"
+  integrity sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==
 
 server-only@^0.0.1:
   version "0.0.1"
@@ -5268,7 +5268,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-side-channel-list@^1.0.0:
+side-channel-list@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
   integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
@@ -5298,13 +5298,13 @@ side-channel-weakmap@^1.0.2:
     side-channel-map "^1.0.1"
 
 side-channel@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
-  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
   dependencies:
     es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-    side-channel-list "^1.0.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
@@ -5472,27 +5472,28 @@ string.prototype.repeat@^1.0.0:
     es-abstract "^1.17.5"
 
 string.prototype.trim@^1.2.10:
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz#40b2dd5ee94c959b4dcfb1d65ce72e90da480c81"
-  integrity sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz#e6bd19cda3985d05a42dda31f3ddf4d35d3430e3"
+  integrity sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==
   dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.2"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
     define-data-property "^1.1.4"
     define-properties "^1.2.1"
-    es-abstract "^1.23.5"
-    es-object-atoms "^1.0.0"
+    es-abstract "^1.24.2"
+    es-object-atoms "^1.1.2"
     has-property-descriptors "^1.0.2"
+    safe-regex-test "^1.1.0"
 
 string.prototype.trimend@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz#62e2731272cd285041b36596054e9f66569b6942"
-  integrity sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz#be6bcf4f3fe0460bdeccdb2cf4f971b310f8346e"
+  integrity sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==
   dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.2"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
     define-properties "^1.2.1"
-    es-object-atoms "^1.0.0"
+    es-object-atoms "^1.1.2"
 
 string.prototype.trimstart@^1.0.8:
   version "1.0.8"
@@ -5900,9 +5901,9 @@ which-collection@^1.0.2:
     is-weakset "^2.0.3"
 
 which-typed-array@^1.1.16, which-typed-array@^1.1.19:
-  version "1.1.21"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.21.tgz#ea7aab68168079646af06b4a36a6f7d7b72e1c0a"
-  integrity sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
+  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
   dependencies:
     available-typed-arrays "^1.0.7"
     call-bind "^1.0.9"


### PR DESCRIPTION
## Summary

- Replaces SPM (`spm_dependency`) with a standard CocoaPods HTTP binary pod for `SpotifyiOS`, downloaded at `pod install` — no Spotify binaries in npm.
- Config plugin injects `pod 'SpotifyiOS', :podspec => ...` into the app Podfile on `expo prebuild`; `expo-module.config.json` `podspecPath` prevents duplicate autolinking.
- Adds `scripts/verify-npm-pack.sh` (CI + `prepublishOnly`) to assert tarball shape.

Targets apps using `ios.useFrameworks: "static"` where SPM failed. See [ADR-0009](docs/adr/0009-ios-spotify-sdk-via-cocoapods-binary-pod.md).

## Test plan

- [ ] Point parent app at this branch (or packed tarball) and run `npx expo prebuild --clean`
- [ ] Confirm Podfile contains the generated `pod 'SpotifyiOS', :podspec => ...` line
- [ ] `cd ios && pod install` — CocoaPods downloads Spotify iOS SDK v5.0.1 tarball
- [ ] Build with `ios.useFrameworks: "static"` — no SPM / no build-from-source for SpotifyiOS
- [ ] Smoke-test auth + App Remote in the parent app


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* iOS Spotify SDK now uses CocoaPods binary pod distribution instead of SPM, with automatic Podfile configuration injection.

**Documentation**
* Updated guides and contribution docs to reflect the new iOS SDK distribution approach.

**Tests**
* Added test coverage for iOS Podfile configuration.

**Chores**
* Enhanced npm packaging verification and CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->