### PR TITLE
fix(ios): avoid SIGABRT when NSError description key is non-string

### DIFF
--- a/ios/NSError+SafeLocalizedDescription.swift
+++ b/ios/NSError+SafeLocalizedDescription.swift
@@ -5,19 +5,19 @@ extension NSError {
   /// to `String`. When that value is a non-`String` object (Spotify's SDK can deliver an
   /// empty `__NSDictionary0`), the bridge sends `-length` to a dictionary and aborts.
   var safeLocalizedDescription: String {
-    if let value = userInfo[NSLocalizedDescriptionKey], !(value is String) {
-      return ""
+    guard let value = userInfo[NSLocalizedDescriptionKey] else {
+      return localizedDescription
     }
-    return localizedDescription
+    return (value as? String) ?? ""
   }
 
   /// Same force-bridge hazard as `localizedDescription`, but for
   /// `NSLocalizedFailureReasonErrorKey`.
   var safeLocalizedFailureReason: String? {
-    if let value = userInfo[NSLocalizedFailureReasonErrorKey], !(value is String) {
-      return nil
+    guard let value = userInfo[NSLocalizedFailureReasonErrorKey] else {
+      return localizedFailureReason
     }
-    return localizedFailureReason
+    return value as? String
   }
 }
 

--- a/ios/NSError+SafeLocalizedDescription.swift
+++ b/ios/NSError+SafeLocalizedDescription.swift
@@ -20,3 +20,21 @@ extension NSError {
     return localizedFailureReason
   }
 }
+
+extension Error {
+  /// Summary for logging that avoids `String(describing:)` / `localizedDescription`
+  /// force-bridges on poisoned `userInfo` values.
+  var safeLogSummary: String {
+    let nsError = self as NSError
+    let description = nsError.safeLocalizedDescription
+    if description.isEmpty {
+      return "\(nsError.domain) code \(nsError.code)"
+    }
+    return "\(nsError.domain) code \(nsError.code): \(description)"
+  }
+}
+
+func safeLogSummary(for error: (any Error)?) -> String {
+  guard let error else { return "nil" }
+  return error.safeLogSummary
+}

--- a/ios/NSError+SafeLocalizedDescription.swift
+++ b/ios/NSError+SafeLocalizedDescription.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension NSError {
+  /// `NSError.localizedDescription` force-bridges `userInfo[NSLocalizedDescriptionKey]`
+  /// to `String`. When that value is a non-`String` object (Spotify's SDK can deliver an
+  /// empty `__NSDictionary0`), the bridge sends `-length` to a dictionary and aborts.
+  var safeLocalizedDescription: String {
+    if let value = userInfo[NSLocalizedDescriptionKey], !(value is String) {
+      return ""
+    }
+    return localizedDescription
+  }
+
+  /// Same force-bridge hazard as `localizedDescription`, but for
+  /// `NSLocalizedFailureReasonErrorKey`.
+  var safeLocalizedFailureReason: String? {
+    if let value = userInfo[NSLocalizedFailureReasonErrorKey], !(value is String) {
+      return nil
+    }
+    return localizedFailureReason
+  }
+}

--- a/ios/SpotifyAppRemoteConnection.swift
+++ b/ios/SpotifyAppRemoteConnection.swift
@@ -210,12 +210,12 @@ final class SpotifyAppRemoteDelegateBridge: NSObject, SPTAppRemoteDelegate {
   }
 
   func appRemote(_ appRemote: SPTAppRemote, didFailConnectionAttemptWithError error: (any Error)?) {
-    NSLog("[ExpoSpotifySDK] AppRemote: connection failed — %@", String(describing: error))
+    NSLog("[ExpoSpotifySDK] AppRemote: connection failed — %@", safeLogSummary(for: error))
     Task { await coordinator?.didFailToConnect(error: error) }
   }
 
   func appRemote(_ appRemote: SPTAppRemote, didDisconnectWithError error: (any Error)?) {
-    NSLog("[ExpoSpotifySDK] AppRemote: disconnected — %@", String(describing: error))
+    NSLog("[ExpoSpotifySDK] AppRemote: disconnected — %@", safeLogSummary(for: error))
     Task { await coordinator?.didDisconnect(error: error) }
   }
 }

--- a/ios/SpotifyAppRemoteCoordinator.swift
+++ b/ios/SpotifyAppRemoteCoordinator.swift
@@ -421,7 +421,7 @@ actor SpotifyAppRemoteCoordinator {
 
   func describeNSError(_ error: NSError) -> String {
     var parts: [String] = ["\(error.domain) code \(error.code)"]
-    let desc = error.localizedDescription
+    let desc = error.safeLocalizedDescription
     if !desc.isEmpty { parts.append("\"\(desc)\"") }
     if let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError {
       parts.append("→ \(describeNSError(underlying))")

--- a/ios/SpotifyAppRemoteErrorMapping.swift
+++ b/ios/SpotifyAppRemoteErrorMapping.swift
@@ -31,70 +31,70 @@ enum SpotifyAppRemoteErrorMapping {
 
   static func mapPlayerError(_ error: NSError, callsite: String) -> NativePlayerError {
     guard isSPTError(error) else {
-      return .unknown(error.localizedDescription)
+      return .unknown(error.safeLocalizedDescription)
     }
     if isConnectionTerminated(error) {
       return .connectionLost(connectionLostMessage(callsite: callsite))
     }
     if isInvalidArguments(error) {
-      let desc = error.localizedDescription.lowercased()
+      let desc = error.safeLocalizedDescription.lowercased()
       if desc.contains("uri") {
-        return .invalidURI("\(callsite): \(error.localizedDescription)")
+        return .invalidURI("\(callsite): \(error.safeLocalizedDescription)")
       }
-      return .invalidParameter(error.localizedDescription)
+      return .invalidParameter(error.safeLocalizedDescription)
     }
     if isRequestFailed(error) {
-      let desc = error.localizedDescription.lowercased()
+      let desc = error.safeLocalizedDescription.lowercased()
       if desc.contains("premium") {
         return .premiumRequired("\(callsite): Spotify Premium is required for on-demand playback")
       }
-      if containsRestriction(error.localizedDescription) {
-        return .operationNotAllowed("\(callsite): \(error.localizedDescription)")
+      if containsRestriction(error.safeLocalizedDescription) {
+        return .operationNotAllowed("\(callsite): \(error.safeLocalizedDescription)")
       }
-      return .unknown(error.localizedDescription)
+      return .unknown(error.safeLocalizedDescription)
     }
-    return .unknown(error.localizedDescription)
+    return .unknown(error.safeLocalizedDescription)
   }
 
   static func mapUserError(_ error: NSError, callsite: String) -> NativeUserError {
     guard isSPTError(error) else {
-      return .unknown(error.localizedDescription)
+      return .unknown(error.safeLocalizedDescription)
     }
     if isConnectionTerminated(error) {
       return .connectionLost(connectionLostMessage(callsite: callsite))
     }
     if isInvalidArguments(error) {
-      return .invalidURI("\(callsite): \(error.localizedDescription)")
+      return .invalidURI("\(callsite): \(error.safeLocalizedDescription)")
     }
     if isRequestFailed(error) {
-      if containsRestriction(error.localizedDescription) {
-        return .operationNotAllowed("\(callsite): \(error.localizedDescription)")
+      if containsRestriction(error.safeLocalizedDescription) {
+        return .operationNotAllowed("\(callsite): \(error.safeLocalizedDescription)")
       }
-      return .unknown(error.localizedDescription)
+      return .unknown(error.safeLocalizedDescription)
     }
-    return .unknown(error.localizedDescription)
+    return .unknown(error.safeLocalizedDescription)
   }
 
   static func mapContentError(_ error: NSError, callsite: String) -> NativeContentError {
     guard isSPTError(error) else {
-      return .unknown(error.localizedDescription)
+      return .unknown(error.safeLocalizedDescription)
     }
     if isConnectionTerminated(error) {
       return .connectionLost(connectionLostMessage(callsite: callsite))
     }
     if isRequestFailed(error) {
-      let desc = error.localizedDescription.lowercased()
+      let desc = error.safeLocalizedDescription.lowercased()
       if desc.contains("not supported") || desc.contains("unsupported") {
         return .contentAPIUnavailable("\(callsite): content API is unavailable on this Spotify app version")
       }
-      return .unknown(error.localizedDescription)
+      return .unknown(error.safeLocalizedDescription)
     }
-    return .unknown(error.localizedDescription)
+    return .unknown(error.safeLocalizedDescription)
   }
 
   static func mapImagesError(_ error: NSError, callsite: String) -> NativeImagesError {
     guard isSPTError(error) else {
-      return .unknown(error.localizedDescription)
+      return .unknown(error.safeLocalizedDescription)
     }
     if isConnectionTerminated(error) {
       return .notConnected(connectionLostMessage(callsite: callsite))
@@ -105,6 +105,6 @@ enum SpotifyAppRemoteErrorMapping {
     if isRequestFailed(error) {
       return .imageLoadFailed("\(callsite): Spotify rejected image request")
     }
-    return .unknown(error.localizedDescription)
+    return .unknown(error.safeLocalizedDescription)
   }
 }

--- a/ios/SpotifyAppRemoteErrorMapping.swift
+++ b/ios/SpotifyAppRemoteErrorMapping.swift
@@ -30,71 +30,75 @@ enum SpotifyAppRemoteErrorMapping {
   }
 
   static func mapPlayerError(_ error: NSError, callsite: String) -> NativePlayerError {
+    let desc = error.safeLocalizedDescription
     guard isSPTError(error) else {
-      return .unknown(error.safeLocalizedDescription)
+      return .unknown(desc)
     }
     if isConnectionTerminated(error) {
       return .connectionLost(connectionLostMessage(callsite: callsite))
     }
     if isInvalidArguments(error) {
-      let desc = error.safeLocalizedDescription.lowercased()
-      if desc.contains("uri") {
-        return .invalidURI("\(callsite): \(error.safeLocalizedDescription)")
+      let lower = desc.lowercased()
+      if lower.contains("uri") {
+        return .invalidURI("\(callsite): \(desc)")
       }
-      return .invalidParameter(error.safeLocalizedDescription)
+      return .invalidParameter(desc)
     }
     if isRequestFailed(error) {
-      let desc = error.safeLocalizedDescription.lowercased()
-      if desc.contains("premium") {
+      let lower = desc.lowercased()
+      if lower.contains("premium") {
         return .premiumRequired("\(callsite): Spotify Premium is required for on-demand playback")
       }
-      if containsRestriction(error.safeLocalizedDescription) {
-        return .operationNotAllowed("\(callsite): \(error.safeLocalizedDescription)")
+      if containsRestriction(desc) {
+        return .operationNotAllowed("\(callsite): \(desc)")
       }
-      return .unknown(error.safeLocalizedDescription)
+      return .unknown(desc)
     }
-    return .unknown(error.safeLocalizedDescription)
+    return .unknown(desc)
   }
 
   static func mapUserError(_ error: NSError, callsite: String) -> NativeUserError {
+    let desc = error.safeLocalizedDescription
     guard isSPTError(error) else {
-      return .unknown(error.safeLocalizedDescription)
+      return .unknown(desc)
     }
     if isConnectionTerminated(error) {
       return .connectionLost(connectionLostMessage(callsite: callsite))
     }
     if isInvalidArguments(error) {
-      return .invalidURI("\(callsite): \(error.safeLocalizedDescription)")
+      return .invalidURI("\(callsite): \(desc)")
     }
     if isRequestFailed(error) {
-      if containsRestriction(error.safeLocalizedDescription) {
-        return .operationNotAllowed("\(callsite): \(error.safeLocalizedDescription)")
+      if containsRestriction(desc) {
+        return .operationNotAllowed("\(callsite): \(desc)")
       }
-      return .unknown(error.safeLocalizedDescription)
+      return .unknown(desc)
     }
-    return .unknown(error.safeLocalizedDescription)
+    return .unknown(desc)
   }
 
   static func mapContentError(_ error: NSError, callsite: String) -> NativeContentError {
+    let desc = error.safeLocalizedDescription
     guard isSPTError(error) else {
-      return .unknown(error.safeLocalizedDescription)
+      return .unknown(desc)
     }
     if isConnectionTerminated(error) {
       return .connectionLost(connectionLostMessage(callsite: callsite))
     }
     if isRequestFailed(error) {
-      let desc = error.safeLocalizedDescription.lowercased()
-      if desc.contains("not supported") || desc.contains("unsupported") {
+      let lower = desc.lowercased()
+      if lower.contains("not supported") || lower.contains("unsupported") {
         return .contentAPIUnavailable("\(callsite): content API is unavailable on this Spotify app version")
       }
-      return .unknown(error.safeLocalizedDescription)
+      return .unknown(desc)
     }
-    return .unknown(error.safeLocalizedDescription)
+    return .unknown(desc)
   }
 
   static func mapImagesError(_ error: NSError, callsite: String) -> NativeImagesError {
+    let desc = error.safeLocalizedDescription
     guard isSPTError(error) else {
-      return .unknown(error.safeLocalizedDescription)
+      return .unknown(desc)
     }
     if isConnectionTerminated(error) {
       return .notConnected(connectionLostMessage(callsite: callsite))
@@ -105,6 +109,6 @@ enum SpotifyAppRemoteErrorMapping {
     if isRequestFailed(error) {
       return .imageLoadFailed("\(callsite): Spotify rejected image request")
     }
-    return .unknown(error.safeLocalizedDescription)
+    return .unknown(desc)
   }
 }

--- a/ios/SpotifyAuthCoordinator.swift
+++ b/ios/SpotifyAuthCoordinator.swift
@@ -138,7 +138,7 @@ final class SpotifySessionDelegateBridge: NSObject, SPTSessionManagerDelegate {
   }
 
   func sessionManager(manager _: SPTSessionManager, didFailWith error: Error) {
-    NSLog("[ExpoSpotifySDK] didFailWithError %@", String(describing: error))
+    NSLog("[ExpoSpotifySDK] didFailWithError %@", error.safeLogSummary)
     let mapped = SpotifyAuthErrorMapping.classify(
       error,
       context: .init(tokenSwapConfigured: authContext?.tokenSwapURL != nil)

--- a/ios/SpotifyAuthErrorMapping.swift
+++ b/ios/SpotifyAuthErrorMapping.swift
@@ -176,8 +176,8 @@ enum SpotifyAuthErrorMapping {
       "server", "unauthorized", "forbidden", "invalid"
     ]
     let combined = [
-      error.localizedDescription,
-      error.localizedFailureReason ?? "",
+      error.safeLocalizedDescription,
+      error.safeLocalizedFailureReason ?? "",
       error.userInfo[NSLocalizedDescriptionKey] as? String ?? "",
       error.userInfo[NSLocalizedFailureReasonErrorKey] as? String ?? ""
     ].joined(separator: " ").lowercased()
@@ -212,7 +212,7 @@ enum SpotifyAuthErrorMapping {
   /// in-process classification heuristics only.
   private static func describeError(_ error: NSError, redactUserInfo: Bool = false) -> String {
     var parts: [String] = ["\(error.domain) code \(error.code)"]
-    let desc = error.localizedDescription
+    let desc = error.safeLocalizedDescription
     if !desc.isEmpty {
       parts.append("\"\(desc)\"")
     }

--- a/ios/SpotifyAuthErrorMapping.swift
+++ b/ios/SpotifyAuthErrorMapping.swift
@@ -177,9 +177,7 @@ enum SpotifyAuthErrorMapping {
     ]
     let combined = [
       error.safeLocalizedDescription,
-      error.safeLocalizedFailureReason ?? "",
-      error.userInfo[NSLocalizedDescriptionKey] as? String ?? "",
-      error.userInfo[NSLocalizedFailureReasonErrorKey] as? String ?? ""
+      error.safeLocalizedFailureReason ?? ""
     ].joined(separator: " ").lowercased()
 
     if negativeKeywords.contains(where: { combined.contains($0) }) {

--- a/ios/SpotifyTokenRefreshClient.swift
+++ b/ios/SpotifyTokenRefreshClient.swift
@@ -23,7 +23,7 @@ enum SpotifyRefreshError: Error {
     case .invalidURL(let s):
       return "Invalid token refresh URL: \(s)"
     case .network(let err):
-      return err.localizedDescription
+      return (err as NSError).safeLocalizedDescription
     case .http(let status, let body):
       let trimmed = body.map { String($0.prefix(512)) } ?? ""
       return "Token refresh server returned HTTP \(status)\(trimmed.isEmpty ? "" : ": \(trimmed)")"
@@ -127,7 +127,9 @@ struct SpotifyTokenRefreshClient {
       }
       json = parsed
     } catch {
-      throw SpotifyRefreshError.parse("Refresh response was not valid JSON: \(error.localizedDescription)")
+      throw SpotifyRefreshError.parse(
+        "Refresh response was not valid JSON: \((error as NSError).safeLocalizedDescription)"
+      )
     }
 
     guard let accessToken = (json["access_token"] as? String), !accessToken.isEmpty else {


### PR DESCRIPTION
## Summary
- Add `NSError.safeLocalizedDescription` to guard against Spotify SDK errors whose `NSLocalizedDescriptionKey` is a non-string (e.g. an empty `NSDictionary` from a failed token-swap response)
- Route all auth, App Remote, and token-refresh diagnostic reads through the safe helper so classification rejects with a structured `AuthError` instead of aborting with `NSInvalidArgumentException`

## Context
On iOS, reading `NSError.localizedDescription` force-bridges `userInfo[NSLocalizedDescriptionKey]` to `String`. When Spotify's SDK delivers a non-string value there, Foundation sends `-length` to a dictionary → uncaught `NSInvalidArgumentException` → `SIGABRT`. This cannot be caught with Swift `try/catch`.

## Test plan
- [ ] Trigger an auth failure where Spotify returns a malformed `NSError` (token-swap/network failure) and confirm the app rejects with a structured error instead of crashing
- [ ] Verify normal auth cancellation and network errors still classify correctly
- [ ] Smoke-test App Remote error paths still surface meaningful messages


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages across sign-in, token refresh, playback, content, and image failures by safely handling malformed localized error details.
  * Made error descriptions and “unknown” fallbacks more consistent by using safer localized description/failure-reason values.
  * Refined cancellation detection to rely only on the safer localized error information, improving consistency for certain auth interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->