### PR TITLE
fix(android): guard Spotify browser auth when no handler exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* **android:** add browser `<queries>` and preflight auth availability check to prevent fatal `ActivityNotFoundException` when Spotify's browser fallback cannot open `https://accounts.spotify.com`
+
+### Documentation
+
+* clarify `Auth.isAvailable()` Android semantics (Spotify app **or** browser) and document the browser-fallback crash guard
+
 ## [2.3.1](https://github.com/wwdrew/expo-spotify-sdk/compare/expo-spotify-sdk-v2.3.0...expo-spotify-sdk-v2.3.1) (2026-07-07)
 
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Typical integration: authenticate, connect App Remote, then read/control playbac
 
 ```ts
 import { useEffect } from "react";
+import { Platform } from "react-native";
 import {
   Auth,
   AppRemote,
@@ -258,7 +259,11 @@ import {
 
 async function login() {
   if (!Auth.isAvailable()) {
-    throw new Error("Install the Spotify app or a web browser to continue");
+    throw new Error(
+      Platform.OS === "android"
+        ? "Install the Spotify app or a web browser to continue"
+        : "Install the Spotify app to continue",
+    );
   }
 
   // On iOS, clear a leaked in-flight auth before retrying.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ import {
 
 async function login() {
   if (!Auth.isAvailable()) {
-    throw new Error("Install the Spotify app to continue");
+    throw new Error("Install the Spotify app or a web browser to continue");
   }
 
   // On iOS, clear a leaked in-flight auth before retrying.
@@ -447,7 +447,10 @@ Need the deprecated shims temporarily? Pin **`1.x`**: `npm install @wwdrew/expo-
 Run `expo prebuild` after adding the plugin to your config. The plugin injects the required `AndroidManifest.xml` entries.
 
 **`Auth.isAvailable()` returns `false` on Android 11+ release builds**
-Android 11+ requires a `<queries>` element to inspect other apps' package names. The module ships this in its `AndroidManifest.xml`; make sure you are not merging a custom manifest that removes it.
+Android 11+ requires a `<queries>` element to inspect other apps' package names. The module ships this in its `AndroidManifest.xml` (Spotify package + `https`/`http` VIEW intents for browser fallback); make sure you are not merging a custom manifest that removes it.
+
+**Android: app crashes with `ActivityNotFoundException` opening `https://accounts.spotify.com`**
+The Spotify auth SDK throws an uncaught exception when its browser fallback cannot resolve a handler. From module **2.3.2+**, `Auth.authenticate()` runs a preflight check and rejects with `SPOTIFY_NOT_INSTALLED` instead. Upgrade the module and ensure the merged manifest includes the module's `<queries>` entries (run `expo prebuild --clean` if needed).
 
 **iOS: authentication never returns**
 Ensure your app's URL scheme is registered in Xcode under **Info → URL Types** and that it matches the `scheme` in the plugin config. The `expo prebuild` step does this automatically; if you have a bare workflow, check `CFBundleURLSchemes` in `Info.plist`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,9 +37,21 @@ android {
     versionCode 1
     versionName "0.5.0"
     consumerProguardFiles "consumer-rules.pro"
+    manifestPlaceholders = [
+      spotifyClientId: "unit-test-client-id",
+      spotifyRedirectUri: "unit-test://authenticate",
+      redirectHostName: "authenticate",
+      redirectPathPattern: ".*",
+      redirectSchemeName: "unit-test",
+    ]
   }
   lintOptions {
     abortOnError false
+  }
+  testOptions {
+    unitTests {
+      includeAndroidResources = true
+    }
   }
 }
 
@@ -60,4 +72,10 @@ dependencies {
   implementation "com.squareup.okhttp3:okhttp:4.12.0"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
+
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "androidx.test:core:1.6.1"
+  testImplementation "org.robolectric:robolectric:4.14.1"
+  testImplementation "org.mockito:mockito-core:5.14.2"
+  testImplementation "org.mockito.kotlin:mockito-kotlin:5.4.0"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,6 +2,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
         <package android:name="com.spotify.music" />
+        <!-- Android 11+ package visibility: lets CustomTabsSupportChecker and our
+             preflight guard resolve browsers for https://accounts.spotify.com. -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="http" />
+        </intent>
     </queries>
     <application>
         <meta-data

--- a/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt
@@ -47,15 +47,6 @@ class ExpoSpotifySDKModule : Module() {
     return SpotifyManifestConfig(clientId = clientId, redirectUri = redirectUri)
   }
 
-  private fun isSpotifyInstalled(): Boolean {
-    return try {
-      context.packageManager.getPackageInfo("com.spotify.music", 0)
-      true
-    } catch (_: PackageManager.NameNotFoundException) {
-      false
-    }
-  }
-
   private fun emitSession(type: String, payload: SpotifySessionPayload) {
     sendEvent(
       EVENT_SESSION_CHANGE,
@@ -100,7 +91,7 @@ class ExpoSpotifySDKModule : Module() {
     // ── Auth ────────────────────────────────────────────────────────────────
 
     Function("isAvailable") {
-      isSpotifyInstalled()
+      SpotifyAuthAvailability.isAuthAvailable(context)
     }
 
     RegisterActivityContracts {
@@ -113,6 +104,7 @@ class ExpoSpotifySDKModule : Module() {
           throw InvalidConfigException("`scopes` must contain at least one entry")
         }
         val manifest = readManifestConfig()
+        SpotifyAuthAvailability.ensureAuthAvailable(context)
 
         val responseType =
           if (config.tokenSwapURL != null) AuthorizationResponse.Type.CODE

--- a/android/src/main/java/expo/modules/spotifysdk/SpotifyAuthAvailability.kt
+++ b/android/src/main/java/expo/modules/spotifysdk/SpotifyAuthAvailability.kt
@@ -1,0 +1,58 @@
+package expo.modules.spotifysdk
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+
+/**
+ * Checks whether Spotify auth can start without hitting the Spotify SDK's
+ * browser fallback crash (ActivityNotFoundException when no handler exists for
+ * https://accounts.spotify.com).
+ */
+object SpotifyAuthAvailability {
+  private const val SPOTIFY_PACKAGE = "com.spotify.music"
+
+  /** Same URL the Spotify auth SDK opens in Custom Tabs / browser fallback. */
+  private val SPOTIFY_ACCOUNTS_URI: Uri = Uri.parse("https://accounts.spotify.com")
+
+  fun isSpotifyInstalled(packageManager: PackageManager): Boolean {
+    return try {
+      packageManager.getPackageInfo(SPOTIFY_PACKAGE, 0)
+      true
+    } catch (_: PackageManager.NameNotFoundException) {
+      false
+    }
+  }
+
+  /**
+   * Returns true when some app on the device can handle Spotify's web auth URL.
+   * Requires the module manifest `<queries>` for https VIEW intents on Android 11+.
+   */
+  fun canOpenSpotifyAuthInBrowser(packageManager: PackageManager): Boolean {
+    val intent = Intent(Intent.ACTION_VIEW, SPOTIFY_ACCOUNTS_URI).apply {
+      addCategory(Intent.CATEGORY_BROWSABLE)
+    }
+    return packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null
+  }
+
+  /** Native Spotify app auth, or web fallback via an installed browser. */
+  fun isAuthAvailable(context: Context): Boolean {
+    val packageManager = context.packageManager
+    return isSpotifyInstalled(packageManager) || canOpenSpotifyAuthInBrowser(packageManager)
+  }
+
+  /**
+   * Throws [SpotifyNotInstalledException] before launching LoginActivity when
+   * neither auth path is available — avoids an uncaught native crash inside the
+   * Spotify auth SDK's browser fallback handler.
+   */
+  fun ensureAuthAvailable(context: Context) {
+    if (isAuthAvailable(context)) {
+      return
+    }
+    throw SpotifyNotInstalledException(
+      "The Spotify app is not installed and no browser is available to complete sign-in",
+    )
+  }
+}

--- a/android/src/test/java/expo/modules/spotifysdk/SpotifyAuthAvailabilityTest.kt
+++ b/android/src/test/java/expo/modules/spotifysdk/SpotifyAuthAvailabilityTest.kt
@@ -1,0 +1,137 @@
+package expo.modules.spotifysdk
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import android.net.Uri
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class SpotifyAuthAvailabilityTest {
+  private val spotifyPackage = "com.spotify.music"
+  private val accountsUri = Uri.parse("https://accounts.spotify.com")
+
+  private fun browserIntent(): Intent =
+    Intent(Intent.ACTION_VIEW, accountsUri).apply {
+      addCategory(Intent.CATEGORY_BROWSABLE)
+    }
+
+  private fun packageManagerWith(
+    spotifyInstalled: Boolean,
+    browserAvailable: Boolean,
+  ): PackageManager {
+    val packageManager = mock<PackageManager>()
+    if (spotifyInstalled) {
+      whenever(packageManager.getPackageInfo(spotifyPackage, 0)).thenReturn(mock())
+    } else {
+      whenever(packageManager.getPackageInfo(spotifyPackage, 0))
+        .thenThrow(PackageManager.NameNotFoundException())
+    }
+    whenever(
+      packageManager.resolveActivity(any(), eq(PackageManager.MATCH_DEFAULT_ONLY)),
+    ).thenReturn(if (browserAvailable) ResolveInfo() else null)
+    return packageManager
+  }
+
+  private fun contextWith(packageManager: PackageManager): Context {
+    val context = mock<Context>()
+    whenever(context.packageManager).thenReturn(packageManager)
+    return context
+  }
+
+  @Test
+  fun isSpotifyInstalled_returnsTrueWhenPackageExists() {
+    val packageManager = packageManagerWith(spotifyInstalled = true, browserAvailable = false)
+    assertTrue(SpotifyAuthAvailability.isSpotifyInstalled(packageManager))
+  }
+
+  @Test
+  fun isSpotifyInstalled_returnsFalseWhenPackageMissing() {
+    val packageManager = packageManagerWith(spotifyInstalled = false, browserAvailable = true)
+    assertFalse(SpotifyAuthAvailability.isSpotifyInstalled(packageManager))
+  }
+
+  @Test
+  fun canOpenSpotifyAuthInBrowser_returnsTrueWhenHandlerExists() {
+    val packageManager = packageManagerWith(spotifyInstalled = false, browserAvailable = true)
+    assertTrue(SpotifyAuthAvailability.canOpenSpotifyAuthInBrowser(packageManager))
+  }
+
+  @Test
+  fun canOpenSpotifyAuthInBrowser_returnsFalseWhenNoHandlerExists() {
+    val packageManager = packageManagerWith(spotifyInstalled = false, browserAvailable = false)
+    assertFalse(SpotifyAuthAvailability.canOpenSpotifyAuthInBrowser(packageManager))
+  }
+
+  @Test
+  fun isAuthAvailable_trueWhenOnlySpotifyInstalled() {
+    val context = contextWith(packageManagerWith(spotifyInstalled = true, browserAvailable = false))
+    assertTrue(SpotifyAuthAvailability.isAuthAvailable(context))
+  }
+
+  @Test
+  fun isAuthAvailable_trueWhenOnlyBrowserAvailable() {
+    val context = contextWith(packageManagerWith(spotifyInstalled = false, browserAvailable = true))
+    assertTrue(SpotifyAuthAvailability.isAuthAvailable(context))
+  }
+
+  @Test
+  fun isAuthAvailable_falseWhenNeitherAvailable() {
+    val context = contextWith(packageManagerWith(spotifyInstalled = false, browserAvailable = false))
+    assertFalse(SpotifyAuthAvailability.isAuthAvailable(context))
+  }
+
+  @Test
+  fun ensureAuthAvailable_doesNotThrowWhenSpotifyInstalled() {
+    val context = contextWith(packageManagerWith(spotifyInstalled = true, browserAvailable = false))
+    SpotifyAuthAvailability.ensureAuthAvailable(context)
+  }
+
+  @Test
+  fun ensureAuthAvailable_doesNotThrowWhenBrowserAvailable() {
+    val context = contextWith(packageManagerWith(spotifyInstalled = false, browserAvailable = true))
+    SpotifyAuthAvailability.ensureAuthAvailable(context)
+  }
+
+  @Test
+  fun ensureAuthAvailable_throwsSpotifyNotInstalledWhenNeitherAvailable() {
+    val context = contextWith(packageManagerWith(spotifyInstalled = false, browserAvailable = false))
+    val exception = assertThrows(SpotifyNotInstalledException::class.java) {
+      SpotifyAuthAvailability.ensureAuthAvailable(context)
+    }
+    assertEquals("SPOTIFY_NOT_INSTALLED", exception.code)
+  }
+
+  @Test
+  fun mergedManifest_allowsBrowserDetectionOnAndroid11Plus() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    shadowOf(context.packageManager).addResolveInfoForIntent(
+      browserIntent(),
+      ResolveInfo().apply {
+        activityInfo = ActivityInfo().apply {
+          packageName = "com.android.chrome"
+          name = "com.android.chrome.Main"
+        }
+      },
+    )
+
+    assertTrue(SpotifyAuthAvailability.canOpenSpotifyAuthInBrowser(context.packageManager))
+  }
+}

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -35,7 +35,8 @@ On **`main`**, you can also exercise the **typed config plugin** in `app.config.
 
 | # | Test | iOS | Android |
 | --- | --- | --- | --- |
-| A1 | `Auth.isAvailable()` is `true` with Spotify installed | ☐ | ☐ |
+| A1 | `Auth.isAvailable()` is `true` with Spotify installed (iOS) or Spotify installed / browser available (Android) | ☐ | ☐ |
+| A1b | Android: `Auth.authenticate()` rejects `SPOTIFY_NOT_INSTALLED` (not crash) when Spotify and browsers are unavailable | ☐ | ☐ |
 | A2 | `Auth.authenticate()` succeeds (code + swap URLs) | ☐ | ☐ |
 | A3 | `Auth.authenticate()` without swap (TOKEN flow) — note refresh token behavior | ☐ | ☐ |
 | A4 | `Auth.refresh()` renews session when refresh token present | ☐ | ☐ |

--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -36,7 +36,7 @@ On **`main`**, you can also exercise the **typed config plugin** in `app.config.
 | # | Test | iOS | Android |
 | --- | --- | --- | --- |
 | A1 | `Auth.isAvailable()` is `true` with Spotify installed (iOS) or Spotify installed / browser available (Android) | ☐ | ☐ |
-| A1b | Android: `Auth.authenticate()` rejects `SPOTIFY_NOT_INSTALLED` (not crash) when Spotify and browsers are unavailable | ☐ | ☐ |
+| A1b | Android only: `Auth.authenticate()` rejects `SPOTIFY_NOT_INSTALLED` (not crash) when Spotify and browsers are unavailable | N/A | ☐ |
 | A2 | `Auth.authenticate()` succeeds (code + swap URLs) | ☐ | ☐ |
 | A3 | `Auth.authenticate()` without swap (TOKEN flow) — note refresh token behavior | ☐ | ☐ |
 | A4 | `Auth.refresh()` renews session when refresh token present | ☐ | ☐ |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,7 +6,10 @@ Full method and type documentation for the public `@wwdrew/expo-spotify-sdk` sur
 
 #### `Auth.isAvailable(): boolean`
 
-Returns `true` if the Spotify app is installed. Does not throw (not available on unsupported platforms).
+Returns whether Spotify sign-in can proceed on this device. Does not throw.
+
+- **Android:** `true` when the Spotify app is installed **or** a browser can open Spotify's web auth URL (`https://accounts.spotify.com`).
+- **iOS:** `true` when the Spotify app is installed.
 
 #### `Auth.authenticate(config): Promise<SpotifySession>`
 

--- a/docs/auth-error-mapping.md
+++ b/docs/auth-error-mapping.md
@@ -7,7 +7,7 @@ Canonical matrix for mapping native Spotify authentication failures to the publi
 | Platform | Auth flow | Token swap / refresh |
 | --- | --- | --- |
 | iOS | [`ios/SpotifyAuthErrorMapping.swift`](../ios/SpotifyAuthErrorMapping.swift) (`SpotifyAuthErrorMapping.classify`) | [`ios/SpotifyTokenRefreshClient.swift`](../ios/SpotifyTokenRefreshClient.swift) |
-| Android | [`android/.../ExpoSpotifySDKModule.kt`](../android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt) (`authenticateAsync`) | [`android/.../SpotifyTokenSwapClient.kt`](../android/src/main/java/expo/modules/spotifysdk/SpotifyTokenSwapClient.kt) |
+| Android | [`android/.../ExpoSpotifySDKModule.kt`](../android/src/main/java/expo/modules/spotifysdk/ExpoSpotifySDKModule.kt) (`authenticateAsync`), [`android/.../SpotifyAuthAvailability.kt`](../android/src/main/java/expo/modules/spotifysdk/SpotifyAuthAvailability.kt) (preflight) | [`android/.../SpotifyTokenSwapClient.kt`](../android/src/main/java/expo/modules/spotifysdk/SpotifyTokenSwapClient.kt) |
 
 **Shared error taxonomy:** [`android/.../SpotifyErrors.kt`](../android/src/main/java/expo/modules/spotifysdk/SpotifyErrors.kt) (Android `CodedException` classes) and `SpotifyError` in [`ios/SpotifyError.swift`](../ios/SpotifyError.swift) (iOS).
 
@@ -68,6 +68,7 @@ Use this table when changing auth code. **Expected code** is the target `error.c
 | Second concurrent `authenticateAsync` | `AUTH_IN_PROGRESS` | `AuthInProgressException` | `SpotifyError.authInProgress` |
 | Empty `scopes` | `INVALID_CONFIG` | `InvalidConfigException` | `SpotifyError.invalidConfiguration` |
 | Missing plugin / manifest config | `INVALID_CONFIG` | `InvalidConfigException` (manifest) | `SpotifyError.invalidConfiguration` (Info.plist) |
+| Android: Spotify app missing and no browser for web auth | `SPOTIFY_NOT_INSTALLED` | `SpotifyNotInstalledException` (preflight in `SpotifyAuthAvailability.ensureAuthAvailable`) | N/A (native app required on iOS) |
 | CODE response but no `tokenSwapURL` | `INVALID_CONFIG` | `InvalidConfigException` | N/A (iOS always uses SDK swap when URL set) |
 | Spotify returns `Type.ERROR` | `AUTH_ERROR` | `SpotifyAuthErrorException(response.error)` | OAuth / auth rejection heuristics on wrapped error |
 | TOKEN response missing access token | `TOKEN_SWAP_PARSE_ERROR` | `TokenSwapParseException` | SDK parse failure → heuristic or `UNKNOWN` |
@@ -102,7 +103,7 @@ Run on **both** iOS and Android with the example app and a controllable token-sw
 - [ ] **Swap offline** — stop server or use unreachable host → `NETWORK_ERROR`.
 - [ ] **Bad swap URL** — `not-a-url` → `INVALID_CONFIG`.
 - [ ] **Refresh expired** — expired/revoked refresh token (server forwards Spotify's `invalid_grant`) → `REFRESH_TOKEN_EXPIRED`. Other refresh 4xx/5xx → `TOKEN_SWAP_FAILED`.
-- [ ] **Concurrent auth** — fire two `authenticateAsync` calls → second rejects `AUTH_IN_PROGRESS`.
+- [ ] **Android no browser** — device/emulator without a browser and without Spotify installed → `SPOTIFY_NOT_INSTALLED` (not a native crash).
 
 **iOS logs:** filter for `[ExpoSpotifySDK] classifyAuthError classified=` to see native classification during `authenticateAsync` (emitted for both the delegate path and the module-level catch-all).
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -17,7 +17,7 @@ App Remote native → JS mapping details: [app-remote-error-mapping.md](./app-re
 | `TOKEN_SWAP_FAILED` | Swap/refresh server returned non-2xx (other than an expired refresh token) | Fix server; read status + body in `e.message` |
 | `TOKEN_SWAP_PARSE_ERROR` | Swap response was not valid token JSON | Fix server response shape |
 | `REFRESH_TOKEN_EXPIRED` | `Auth.refresh()` failed because the refresh token expired or was revoked (Spotify `invalid_grant`; tokens expire 6 months after issue, from 2026-07-20) | Discard the stored token and send the user through `Auth.authenticate()` again — do not retry the refresh |
-| `SPOTIFY_NOT_INSTALLED` | Spotify app not found (rare — web fallback may still run) | Prompt install or use web auth |
+| `SPOTIFY_NOT_INSTALLED` | Spotify app not found **and** (Android) no browser for web fallback; also thrown by the Android preflight guard before LoginActivity | Prompt install, enable a browser, or explain the device cannot complete sign-in |
 | `AUTH_ERROR` | Spotify rejected the authorization | Check Dashboard redirect URI, scopes, test users |
 | `UNKNOWN` | Unexpected native failure | Read `e.message` / `e.cause`; file an issue with logs. On iOS before Expo SDK 57 a real code (e.g. `USER_CANCELLED`) can surface as `UNKNOWN` with the correct message — see the [known iOS limitation](./auth-error-mapping.md#known-ios-limitation-code-dropped-on-async-rejection-expo--sdk-57) |
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -4,13 +4,6 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
-  <queries>
-    <intent>
-      <action android:name="android.intent.action.VIEW"/>
-      <category android:name="android.intent.category.BROWSABLE"/>
-      <data android:scheme="https"/>
-    </intent>
-  </queries>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true" android:enableOnBackInvokedCallback="false">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.ENABLE_BSDIFF_PATCH_SUPPORT" android:value="true"/>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,13 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <category android:name="android.intent.category.BROWSABLE"/>
+      <data android:scheme="https"/>
+    </intent>
+  </queries>
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true" android:enableOnBackInvokedCallback="false">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.ENABLE_BSDIFF_PATCH_SUPPORT" android:value="true"/>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -78,7 +78,7 @@ PODS:
     - RNScreens
   - ExpoSplashScreen (56.0.10):
     - ExpoModulesCore
-  - ExpoSpotifySDK (2.2.2):
+  - ExpoSpotifySDK (2.3.1):
     - ExpoModulesCore
     - SpotifyiOS
   - ExpoSymbols (56.0.6):
@@ -2381,7 +2381,7 @@ SPEC CHECKSUMS:
   ExpoModulesWorklets: 25d712f4e0a4eb37397d46c0ff5b450eca897fd1
   ExpoRouter: 5539806fcab8d38c639c9c255a6d73caa839436a
   ExpoSplashScreen: 3fe3a57d56d7242a9109d9714a6f9fa1e256538b
-  ExpoSpotifySDK: 5990aa533b33014601bdc62dce0120a7745cb963
+  ExpoSpotifySDK: 46dcfe7dfbf3e6b4ca306a744167a5127eced4ff
   ExpoSymbols: 377747de25bcb1ab68ec68f23d81fb81d43eae83
   ExpoSystemUI: 8f4fb641c6a6ebe2a01dda0fbd3fdd952ab5823a
   ExpoUI: cb2928f5537135cff59e7b84b4adbeb72355f9fd

--- a/example/ios/expospotifysdkexample.xcodeproj/project.pbxproj
+++ b/example/ios/expospotifysdkexample.xcodeproj/project.pbxproj
@@ -8,28 +8,28 @@
 
 /* Begin PBXBuildFile section */
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		1F3C493647E9A6D5C3445C41 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 12BD31505B7E76DC8F2FEA3D /* PrivacyInfo.xcprivacy */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		420D223D70D45CECE0836C77 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDF8ED7F8922CB9AAAD4343 /* ExpoModulesProvider.swift */; };
-		77B8F7CE079FB8672DA9797C /* libPods-expospotifysdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AB67FF6CAFFACE5447FA5095 /* libPods-expospotifysdkexample.a */; };
-		AF3002A3D5BD391C5FD7194B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F9E3EAFF1F776A3FD7331F90 /* PrivacyInfo.xcprivacy */; };
+		52AD1E8450C1D569852E9F73 /* libPods-expospotifysdkexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD753ACA944A45BA3B5F568F /* libPods-expospotifysdkexample.a */; };
+		94CC1A4868962E7FDA94A3D4 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9977F109C1DAB2724ECCD6C5 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		12BD31505B7E76DC8F2FEA3D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = expospotifysdkexample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* expospotifysdkexample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = expospotifysdkexample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = expospotifysdkexample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = expospotifysdkexample/Info.plist; sourceTree = "<group>"; };
-		2C851A5C47832AF8F6C9DFC4 /* Pods-expospotifysdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expospotifysdkexample.release.xcconfig"; path = "Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample.release.xcconfig"; sourceTree = "<group>"; };
-		6EDF8ED7F8922CB9AAAD4343 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-expospotifysdkexample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
-		86A824D350E2202ADB6A66EF /* Pods-expospotifysdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expospotifysdkexample.debug.xcconfig"; path = "Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample.debug.xcconfig"; sourceTree = "<group>"; };
+		62B35A2DA580E8472830A025 /* Pods-expospotifysdkexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expospotifysdkexample.release.xcconfig"; path = "Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample.release.xcconfig"; sourceTree = "<group>"; };
+		9977F109C1DAB2724ECCD6C5 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-expospotifysdkexample/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = expospotifysdkexample/SplashScreen.storyboard; sourceTree = "<group>"; };
-		AB67FF6CAFFACE5447FA5095 /* libPods-expospotifysdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-expospotifysdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		CD753ACA944A45BA3B5F568F /* libPods-expospotifysdkexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-expospotifysdkexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = expospotifysdkexample/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* expospotifysdkexample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "expospotifysdkexample-Bridging-Header.h"; path = "expospotifysdkexample/expospotifysdkexample-Bridging-Header.h"; sourceTree = "<group>"; };
-		F9E3EAFF1F776A3FD7331F90 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = expospotifysdkexample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		FEFFBB94D130864077D79039 /* Pods-expospotifysdkexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-expospotifysdkexample.debug.xcconfig"; path = "Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -37,29 +37,19 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				77B8F7CE079FB8672DA9797C /* libPods-expospotifysdkexample.a in Frameworks */,
+				52AD1E8450C1D569852E9F73 /* libPods-expospotifysdkexample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1272C087C74CD55ACA0A8989 /* Pods */ = {
+		01C5ECF25095E95B4338CE00 /* expospotifysdkexample */ = {
 			isa = PBXGroup;
 			children = (
-				86A824D350E2202ADB6A66EF /* Pods-expospotifysdkexample.debug.xcconfig */,
-				2C851A5C47832AF8F6C9DFC4 /* Pods-expospotifysdkexample.release.xcconfig */,
+				9977F109C1DAB2724ECCD6C5 /* ExpoModulesProvider.swift */,
 			);
-			name = Pods;
-			path = Pods;
-			sourceTree = "<group>";
-		};
-		138906169605C61CC9D6413A /* ExpoModulesProviders */ = {
-			isa = PBXGroup;
-			children = (
-				9C0D7E91BAD68A7B244CFD90 /* expospotifysdkexample */,
-			);
-			name = ExpoModulesProviders;
+			name = expospotifysdkexample;
 			sourceTree = "<group>";
 		};
 		13B07FAE1A68108700A75B9A /* expospotifysdkexample */ = {
@@ -71,7 +61,7 @@
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				F9E3EAFF1F776A3FD7331F90 /* PrivacyInfo.xcprivacy */,
+				12BD31505B7E76DC8F2FEA3D /* PrivacyInfo.xcprivacy */,
 			);
 			name = expospotifysdkexample;
 			sourceTree = "<group>";
@@ -80,7 +70,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				AB67FF6CAFFACE5447FA5095 /* libPods-expospotifysdkexample.a */,
+				CD753ACA944A45BA3B5F568F /* libPods-expospotifysdkexample.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -99,8 +89,8 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				1272C087C74CD55ACA0A8989 /* Pods */,
-				138906169605C61CC9D6413A /* ExpoModulesProviders */,
+				AB552D909ADB0861D05A8327 /* Pods */,
+				FBA06D4CCB4D3A6DE95EF8E2 /* ExpoModulesProviders */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -115,12 +105,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		9C0D7E91BAD68A7B244CFD90 /* expospotifysdkexample */ = {
+		AB552D909ADB0861D05A8327 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				6EDF8ED7F8922CB9AAAD4343 /* ExpoModulesProvider.swift */,
+				FEFFBB94D130864077D79039 /* Pods-expospotifysdkexample.debug.xcconfig */,
+				62B35A2DA580E8472830A025 /* Pods-expospotifysdkexample.release.xcconfig */,
 			);
-			name = expospotifysdkexample;
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		BB2F792B24A3F905000567C9 /* Supporting */ = {
@@ -132,6 +124,14 @@
 			path = expospotifysdkexample/Supporting;
 			sourceTree = "<group>";
 		};
+		FBA06D4CCB4D3A6DE95EF8E2 /* ExpoModulesProviders */ = {
+			isa = PBXGroup;
+			children = (
+				01C5ECF25095E95B4338CE00 /* expospotifysdkexample */,
+			);
+			name = ExpoModulesProviders;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -140,13 +140,13 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "expospotifysdkexample" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				01AC04C0F88D3641E145F350 /* [Expo] Configure project */,
+				011C519FCF4ABA825D2740A0 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				83E39165680A4F671235A6FB /* [CP] Embed Pods Frameworks */,
+				B6C5B2832CB329ADA7C1EE6D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -196,7 +196,7 @@
 				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
-				AF3002A3D5BD391C5FD7194B /* PrivacyInfo.xcprivacy in Resources */,
+				1F3C493647E9A6D5C3445C41 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -220,7 +220,7 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
 		};
-		01AC04C0F88D3641E145F350 /* [Expo] Configure project */ = {
+		011C519FCF4ABA825D2740A0 /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -296,7 +296,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-expospotifysdkexample/Pods-expospotifysdkexample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		83E39165680A4F671235A6FB /* [CP] Embed Pods Frameworks */ = {
+		B6C5B2832CB329ADA7C1EE6D /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -338,7 +338,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
-				420D223D70D45CECE0836C77 /* ExpoModulesProvider.swift in Sources */,
+				94CC1A4868962E7FDA94A3D4 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -347,7 +347,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 86A824D350E2202ADB6A66EF /* Pods-expospotifysdkexample.debug.xcconfig */;
+			baseConfigurationReference = FEFFBB94D130864077D79039 /* Pods-expospotifysdkexample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -384,7 +384,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2C851A5C47832AF8F6C9DFC4 /* Pods-expospotifysdkexample.release.xcconfig */;
+			baseConfigurationReference = 62B35A2DA580E8472830A025 /* Pods-expospotifysdkexample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -417,7 +417,9 @@ export function HomeScreen() {
         <View style={s.badgeRow}>
           <View style={[s.dot, { backgroundColor: Auth.isAvailable() ? C.green : C.muted }]} />
           <Text style={s.badgeText}>
-            {Auth.isAvailable() ? "Spotify app detected" : "Spotify app not installed"}
+            {Auth.isAvailable()
+              ? "Spotify sign-in available"
+              : "Spotify sign-in unavailable (install Spotify or a browser)"}
           </Text>
         </View>
         <Text style={s.connectionText}>{connectionLabel}</Text>

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Linking,
+  Platform,
   ScrollView,
   Text,
   View,
@@ -419,7 +420,9 @@ export function HomeScreen() {
           <Text style={s.badgeText}>
             {Auth.isAvailable()
               ? "Spotify sign-in available"
-              : "Spotify sign-in unavailable (install Spotify or a browser)"}
+              : Platform.OS === "android"
+                ? "Spotify sign-in unavailable (install Spotify or a browser)"
+                : "Spotify sign-in unavailable (install Spotify)"}
           </Text>
         </View>
         <Text style={s.connectionText}>{connectionLabel}</Text>

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -161,7 +161,12 @@ function normaliseSession(raw: unknown): SpotifySession {
  */
 export const Auth = {
   /**
-   * Returns `true` if the Spotify app is installed on the device.
+   * Returns whether Spotify sign-in can proceed on this device.
+   *
+   * - **Android:** `true` when the Spotify app is installed **or** a browser can
+   *   open Spotify's web auth flow (needed when the app is not installed).
+   * - **iOS:** `true` when the Spotify app is installed (web auth uses the
+   *   system authentication session and does not require a separate check).
    */
   isAvailable(): boolean {
     return ExpoSpotifySDKModule.isAvailable();

--- a/src/internal/auth-error-mapping.fixture.json
+++ b/src/internal/auth-error-mapping.fixture.json
@@ -14,7 +14,7 @@
     "AUTH_ERROR",
     "UNKNOWN"
   ],
-  "passthroughCodesDescription": "Public codes thrown directly by a dedicated code path rather than produced by the ambiguous-error classifier `rules` below, so they intentionally have no classifier rule. REFRESH_TOKEN_EXPIRED is raised by SpotifyTokenRefreshClient (iOS) / SpotifyTokenSwapClient (Android) on an `invalid_grant` refresh response; the others are raised at their throw sites (AuthInProgress/InvalidConfig/SpotifyNotInstalled checks).",
+  "passthroughCodesDescription": "Public codes thrown directly by a dedicated code path rather than produced by the ambiguous-error classifier `rules` below, so they intentionally have no classifier rule. REFRESH_TOKEN_EXPIRED is raised by SpotifyTokenRefreshClient (iOS) / SpotifyTokenSwapClient (Android) on an `invalid_grant` refresh response; the others are raised at their throw sites (AuthInProgress/InvalidConfig/SpotifyNotInstalled checks). On Android, SPOTIFY_NOT_INSTALLED is also raised by SpotifyAuthAvailability.ensureAuthAvailable when neither the Spotify app nor a browser can handle web auth.",
   "passthroughCodes": [
     "AUTH_IN_PROGRESS",
     "INVALID_CONFIG",


### PR DESCRIPTION
## Summary
- Add `SpotifyAuthAvailability` to preflight auth before launching the Spotify SDK, rejecting with `SPOTIFY_NOT_INSTALLED` instead of an uncaught `ActivityNotFoundException` when neither the Spotify app nor a browser can open `https://accounts.spotify.com`
- Ship https/http VIEW intent `<queries>` in the module manifest for Android 11+ package visibility
- Update `Auth.isAvailable()` Android semantics (Spotify app **or** browser) and align docs, error matrix, and example UI copy

## Context
The Spotify Android auth SDK throws an uncaught exception when its browser fallback cannot resolve a handler for the accounts URL. This branch mirrors the SDK's intent check and fails fast with a structured error.

## Test plan
- [ ] Android with Spotify installed: `Auth.isAvailable()` returns `true`; `Auth.authenticate()` succeeds
- [ ] Android without Spotify but with a browser: `Auth.isAvailable()` returns `true`; web auth fallback works
- [ ] Android without Spotify and without a browser (or emulator with no browser): `Auth.authenticate()` rejects `SPOTIFY_NOT_INSTALLED` — no native crash
- [ ] Release build on Android 11+ confirms merged manifest includes module `<queries>` entries


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android sign-in fallback when Spotify is unavailable.
  * Prevented browser fallback crashes by checking whether a compatible browser can open Spotify authentication.
  * Returns `SPOTIFY_NOT_INSTALLED` instead of crashing when neither Spotify nor a browser is available.

* **Documentation**
  * Clarified that Android sign-in is available through Spotify or a supported browser.
  * Updated troubleshooting guidance and error-code behavior.

* **User Experience**
  * Updated availability messages to provide platform-specific sign-in guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->