### PR TITLE
chore(ci): run Android auth availability unit tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,32 @@ jobs:
       - name: Verify example Android package layout
         run: bash scripts/verify-example-android-package.sh
 
+  android-unit-test:
+    name: Android unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: yarn
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Install dependencies
+        run: |
+          yarn install --frozen-lockfile
+          cd example && yarn install --frozen-lockfile
+
+      - name: Run module Android unit tests
+        working-directory: example/android
+        run: ./gradlew :wwdrew-expo-spotify-sdk:testDebugUnitTest --no-daemon
+
   build-ts:
     name: TypeScript build
     runs-on: ubuntu-latest

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,7 +59,7 @@ Both lanes ship the full Auth + App Remote API ([ADR-0006](./docs/adr/0006-names
 ### `2.x` on `main` (Expo SDK 56+)
 
 - npm **`2.x`**, branch **`main`**, iOS 16.4+, `expo-modules-core@^56`
-- Active development; **`2.0.0`** pending Release Please merge
+- Active development; releases automated via Release Please on **`main`**
 - **Typed config plugin** on `main` only: `import { withSpotifySdk } from "@wwdrew/expo-spotify-sdk/plugin"` in `app.config.ts`. Legacy string/tuple plugin syntax remains supported.
 
 **Explicitly not in v1 (or any version):**

--- a/docs/guides/platform-differences.md
+++ b/docs/guides/platform-differences.md
@@ -6,6 +6,7 @@ Cross-platform parity notes for Auth and App Remote.
 | --- | --- | --- |
 | `AppRemote.connect(accessToken)` | Token passed to `SPTAppRemote` | Token accepted for API parity; SDK uses session cached in Spotify app from prior auth |
 | `Auth.cancelPending()` | Clears stuck `SPTSessionManager` state | No-op |
+| `Auth.isAvailable()` | `true` when the Spotify app is installed | `true` when the Spotify app is installed **or** a browser can open `https://accounts.spotify.com` |
 | Refresh token without swap | Possible (iOS TOKEN flow) | Not available — use `tokenSwapURL` |
 | `session.scopes` without swap | Granted scopes returned | Requested scopes only (not granted list) |
 | Premium / player metadata | Full App Remote when Premium | Free accounts often lack track titles / on-demand play |


### PR DESCRIPTION
## Summary
- Add a CI job that runs `SpotifyAuthAvailabilityTest` via Gradle
- Document `Auth.isAvailable()` platform semantics in platform-differences
- Update stale release-lane wording in CONTEXT.md

## Test plan
- [x] `yarn test`
- [x] `./gradlew :wwdrew-expo-spotify-sdk:testDebugUnitTest` (local)
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)